### PR TITLE
fix: realDelegateFromSelector - 避免proxy本身直接或动态实现了该方法

### DIFF
--- a/GrowingAutotrackerCore/Autotrack/UICollectionView+GrowingAutotracker.m
+++ b/GrowingAutotrackerCore/Autotrack/UICollectionView+GrowingAutotracker.m
@@ -28,9 +28,9 @@
 
 - (void)growing_setDelegate:(id<UICollectionViewDelegate>)delegate {
     SEL selector = @selector(collectionView:didSelectItemAtIndexPath:);
-    id realDelegate = [GrowingSwizzler realDelegateFromSelector:selector proxy:delegate];
+    Class class = [GrowingSwizzler realDelegateClassFromSelector:selector proxy:delegate];
     
-    if ([realDelegate respondsToSelector:selector]) {
+    if ([GrowingSwizzler realDelegateClass:class respondsToSelector:selector]) {
         
         void (^didSelectItemBlock)(id, SEL, id, id) = ^(id view, SEL command, UICollectionView *collectionView, NSIndexPath *indexPath) {
                                                  
@@ -41,7 +41,7 @@
         };
         
         [GrowingSwizzler growing_swizzleSelector:selector
-                                         onClass:[realDelegate class]
+                                         onClass:class
                                        withBlock:didSelectItemBlock
                                            named:@"growing_collectionView_didSelect"];
     }

--- a/GrowingAutotrackerCore/Autotrack/UITableView+GrowingAutotracker.m
+++ b/GrowingAutotrackerCore/Autotrack/UITableView+GrowingAutotracker.m
@@ -28,9 +28,10 @@
 
 - (void)growing_setDelegate:(id<UITableViewDelegate>)delegate {
     SEL selector = @selector(tableView:didSelectRowAtIndexPath:);
-    id realDelegate = [GrowingSwizzler realDelegateFromSelector:selector proxy:delegate];
-    if ([realDelegate respondsToSelector:selector]) {
-        
+    Class class = [GrowingSwizzler realDelegateClassFromSelector:selector proxy:delegate];
+    
+    if ([GrowingSwizzler realDelegateClass:class respondsToSelector:selector]) {
+
         void (^didSelectBlock)(id, SEL, id, id) = ^(id view, SEL command, UITableView *tableView, NSIndexPath *indexPath) {
                                                  
             if (tableView && indexPath) {
@@ -39,7 +40,7 @@
             }
         };
         [GrowingSwizzler growing_swizzleSelector:selector
-                                         onClass:[realDelegate class]
+                                         onClass:class
                                        withBlock:didSelectBlock
                                            named:@"growing_tableView_didSelect"];
     }

--- a/GrowingTrackerCore/GrowingSwizzle/GrowingSwizzler.h
+++ b/GrowingTrackerCore/GrowingSwizzle/GrowingSwizzler.h
@@ -33,7 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GrowingSwizzler : NSObject
 //setDelegate时，返回正确的delegate
-+ (id)realDelegateFromSelector:(SEL)selector proxy:(id)proxy;
++ (Class)realDelegateClassFromSelector:(SEL)selector proxy:(id)proxy;
++ (BOOL)realDelegateClass:(Class)cls respondsToSelector:(SEL)sel;
 + (void)growing_swizzleSelector:(SEL)aSelector
                         onClass:(Class)aClass
                       withBlock:(growingSwizzleBlock)aBlock


### PR DESCRIPTION
方法调用的过程中，如果对象本身有具体实现或通过 resolveInstanceMethod 动态添加了实现，则不会进入 forwardingTargetForSelector 中；
在[此项目](https://github.com/YoloMao/RSSwizzleDemo)中 Proxy.m 查看模拟场景