### PR TITLE
fix: 没有释放 realtimeEventDB 数据库的空间

### DIFF
--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -119,6 +119,7 @@ static GrowingEventManager *shareinstance = nil;
                 [GrowingEventDataBase databaseWithPath:[GrowingFileStorage getRealtimeDatabasePath]
                                                   name:[name stringByAppendingString:@"realtimevent"]];
 
+            [self.realtimeEventDB vacuum];
             [self.timingEventDB vacuum];
             [self cleanExpiredData_unsafe];
         }];


### PR DESCRIPTION
vacuum 函数的调用只针对 timingEventDB，是有问题的，将导致 realtimeEventDB 的空闲列表空间永远无法释放。