### PR TITLE
fix: SDK 初始化时的版本日志 level 改成 info，并兼容 debugEnabled 配置

### DIFF
--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -212,7 +212,7 @@ static GrowingEventManager *sharedInstance = nil;
         }
 
         if (!GrowingConfigurationManager.sharedInstance.trackConfiguration.dataCollectionEnabled) {
-            GIOLogWarn(@"Data collection is disabled, event can not build");
+            GIOLogDebug(@"Data collection is disabled, event can not build");
             return;
         }
 

--- a/GrowingTrackerCore/FileStorage/GrowingFileStorage.m
+++ b/GrowingTrackerCore/FileStorage/GrowingFileStorage.m
@@ -164,7 +164,7 @@ NSString *const kGrowingDirCommonPrefix = @"com.growingio.";
     NSURL *url = [self urlForKey:key];
     NSData *data = [NSData dataWithContentsOfURL:url];
     if (!data) {
-        GIOLogWarn(@"WARNING: No data file for key %@", key);
+        GIOLogDebug(@"WARNING: No data file for key %@", key);
         return nil;
     }
     if (self.crypto) {

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -58,20 +58,14 @@ const int GrowingTrackerVersionCode = 30200;
 }
 
 - (void)loggerSetting {
-    if (self.configuration.debugEnabled) {
-        [GrowingLog addLogger:[GrowingTTYLogger sharedInstance] withLevel:GrowingLogLevelDebug];
-    } else {
-        [GrowingLog removeLogger:[GrowingTTYLogger sharedInstance]];
-        [GrowingLog addLogger:[GrowingTTYLogger sharedInstance] withLevel:GrowingLogLevelError];
-    }
-
+    [GrowingLog addLogger:[GrowingTTYLogger sharedInstance] withLevel:self.configuration.debugEnabled ? GrowingLogLevelDebug : GrowingLogLevelInfo];
     [GrowingLog addLogger:[GrowingWSLogger sharedInstance] withLevel:GrowingLogLevelVerbose];
     [GrowingWSLogger sharedInstance].logFormatter = [GrowingWSLoggerFormat new];
 }
 
 - (void)versionPrint {
     NSString *versionStr = [NSString stringWithFormat:@"Thank you very much for using GrowingIO. We will do our best to provide you with the best service. GrowingIO version: %@",GrowingTrackerVersionName];
-    GIOLogError(@"%@",versionStr);
+    GIOLogInfo(@"%@", versionStr);
 }
 
 - (void)trackCustomEvent:(NSString *)eventName {

--- a/GrowingTrackerCore/Manager/GrowingSession.m
+++ b/GrowingTrackerCore/Manager/GrowingSession.m
@@ -139,7 +139,7 @@ static GrowingSession *currentSession = nil;
 - (void)applicationDidBecomeActive {
     // 第一次启动，且已经发送过visit事件，说明visit事件被强制补发了，这里就不在发送visit事件了
     if (self.latestDidEnterBackgroundTime == 0 && self.alreadySendVisitEvent) {
-        GIOLogWarn(@"First launched and already send visit");
+        GIOLogDebug(@"First launched and already send visit");
         return;
     }
 


### PR DESCRIPTION
1. 初始化时的版本日志在 logger 中原 level 为 error，改为 info 更加合理
2. debugEnabled 为 YES 时，level = debug
3. debugEnabled 为 NO 时，level  = info