### PR TITLE
fix: 日志重复打印问题（Xcode console），且在 Release 环境下需不可见（console.app）

### DIFF
--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -5,15 +5,11 @@
 #import "GrowingRealTracker.h"
 #import "GrowingTrackConfiguration.h"
 #import "GrowingAppLifecycle.h"
-#import "GrowingLog.h"
-#import "GrowingTTYLogger.h"
-#import "GrowingWSLogger.h"
+#import "GrowingLogger.h"
 #import "GrowingWSLoggerFormat.h"
-#import "GrowingLogMacros.h"
 #import "GrowingDispatchManager.h"
 #import "NSString+GrowingHelper.h"
 #import "NSDictionary+GrowingHelper.h"
-#import "GrowingLogger.h"
 #import "GrowingDeviceInfo.h"
 #import "GrowingVisitEvent.h"
 #import "GrowingSession.h"
@@ -64,11 +60,23 @@ const int GrowingTrackerVersionCode = 30201;
 }
 
 - (void)loggerSetting {
-    [GrowingLog addLogger:[GrowingTTYLogger sharedInstance] withLevel:self.configuration.debugEnabled ? GrowingLogLevelDebug : GrowingLogLevelInfo];
-    // flutter use this console
-    [GrowingLog addLogger:[GrowingASLLogger sharedInstance] withLevel:self.configuration.debugEnabled ? GrowingLogLevelDebug : GrowingLogLevelInfo];
+    GrowingLogLevel level = self.logLevel;
+    if (@available(iOS 10.0, *)) {
+        [GrowingLog addLogger:[GrowingOSLogger sharedInstance] withLevel:level];
+    }else {
+        [GrowingLog addLogger:[GrowingTTYLogger sharedInstance] withLevel:level];
+        [GrowingLog addLogger:[GrowingASLLogger sharedInstance] withLevel:level];
+    }
     [GrowingLog addLogger:[GrowingWSLogger sharedInstance] withLevel:GrowingLogLevelVerbose];
     [GrowingWSLogger sharedInstance].logFormatter = [GrowingWSLoggerFormat new];
+}
+
+- (GrowingLogLevel)logLevel {
+    GrowingLogLevel level = GrowingLogLevelOff;
+#if defined(DEBUG) && DEBUG
+    level = self.configuration.debugEnabled ? GrowingLogLevelDebug : GrowingLogLevelInfo;
+#endif
+    return level;
 }
 
 - (void)versionPrint {

--- a/GrowingTrackerCore/Thirdparty/GrowingLogger/GrowingLogger.h
+++ b/GrowingTrackerCore/Thirdparty/GrowingLogger/GrowingLogger.h
@@ -82,5 +82,6 @@ FOUNDATION_EXPORT const unsigned char GrowingCocoaLumberjackVersionString[];
 #import "GrowingTTYLogger.h"
 #import "GrowingASLLogger.h"
 #import "GrowingWSLogger.h"
+#import "GrowingOSLogger.h"
 
 static GrowingLogLevel gioLogLevel = GrowingLogLevelAll;

--- a/GrowingTrackerCore/Thirdparty/GrowingLogger/GrowingOSLogger.h
+++ b/GrowingTrackerCore/Thirdparty/GrowingLogger/GrowingOSLogger.h
@@ -1,0 +1,59 @@
+//
+// GrowingOSLogger.h
+// Pods
+//
+//  Created by YoloMao on 2021/8/10.
+//  Copyright (C) 2017 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+// Disable legacy macros
+#ifndef Growing_LEGACY_MACROS
+    #define Growing_LEGACY_MACROS 0
+#endif
+
+#import "GrowingLog.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This class provides a logger for the Apple os_log facility.
+ **/
+API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))
+@interface GrowingOSLogger : GrowingAbstractLogger <GrowingLogger>
+
+/**
+ *  Singleton method
+ *
+ *  @return the shared instance with OS_LOG_DEFAULT.
+ */
+@property (nonatomic, class, readonly, strong) GrowingOSLogger *sharedInstance;
+
+/**
+ Designated initializer
+ 
+ @param subsystem Desired subsystem in log. E.g. "org.example"
+ @param category Desired category in log. E.g. "Point of interests."
+ @return New instance of GrowingOSLogger.
+ 
+ @discussion This method requires either both or no parameter to be set. Much like `(String, String)?` in Swift.
+ If both parameters are nil, this method will return a logger configured with `OS_LOG_DEFAULT`.
+ If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`
+ */
+- (instancetype)initWithSubsystem:(nullable NSString *)subsystem category:(nullable NSString *)category NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GrowingTrackerCore/Thirdparty/GrowingLogger/GrowingOSLogger.m
+++ b/GrowingTrackerCore/Thirdparty/GrowingLogger/GrowingOSLogger.m
@@ -1,0 +1,122 @@
+//
+// GrowingOSLogger.m
+// Pods
+//
+//  Created by YoloMao on 2021/8/10.
+//  Copyright (C) 2017 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+
+#import "GrowingOSLogger.h"
+#import <os/log.h>
+
+@interface GrowingOSLogger () {
+    NSString *_subsystem;
+    NSString *_category;
+}
+
+@property (copy, nonatomic, readonly, nullable) NSString *subsystem;
+@property (copy, nonatomic, readonly, nullable) NSString *category;
+@property (strong, nonatomic, readwrite, nonnull) os_log_t logger;
+
+@end
+
+@implementation GrowingOSLogger
+
+@synthesize subsystem = _subsystem;
+@synthesize category = _category;
+
+#pragma mark - Initialization
+
+/**
+ * Assertion
+ * Swift: (String, String)?
+ */
+- (instancetype)initWithSubsystem:(NSString *)subsystem category:(NSString *)category {
+    NSAssert((subsystem == nil) == (category == nil), @"Either both subsystem and category or neither should be nil.");
+    if (self = [super init]) {
+        _subsystem = [subsystem copy];
+        _category = [category copy];
+    }
+    return self;
+}
+
+static GrowingOSLogger *sharedInstance;
+
+- (instancetype)init {
+    return [self initWithSubsystem:nil category:nil];
+}
+
++ (instancetype)sharedInstance {
+    static dispatch_once_t GrowingOSLoggerOnceToken;
+
+    dispatch_once(&GrowingOSLoggerOnceToken, ^{
+        sharedInstance = [[[self class] alloc] init];
+    });
+
+    return sharedInstance;
+}
+
+#pragma mark - os_log
+
+- (os_log_t)getLogger {
+    if (self.subsystem == nil || self.category == nil) {
+        return OS_LOG_DEFAULT;
+    }
+    return os_log_create(self.subsystem.UTF8String, self.category.UTF8String);
+}
+
+- (os_log_t)logger {
+    if (_logger == nil)  {
+        _logger = [self getLogger];
+    }
+    return _logger;
+}
+
+#pragma mark - GrowingLogger
+
+- (GrowingLoggerName)loggerName {
+    return GrowingLoggerNameOS;
+}
+
+- (void)logMessage:(GrowingLogMessage *)logMessage {
+    // Skip captured log messages
+    if ([logMessage->_fileName isEqualToString:@"GrowingASLLogCapture"]) {
+        return;
+    }
+
+    if (@available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)) {
+        NSString * message = _logFormatter ? [_logFormatter formatLogMessage:logMessage] : logMessage->_message;
+        if (message != nil) {
+            const char *msg = [message UTF8String];
+            __auto_type logger = [self logger];
+            switch (logMessage->_flag) {
+                case GrowingLogFlagError  :
+                    os_log_error(logger, "%{public}s", msg);
+                    break;
+                case GrowingLogFlagWarning:
+                case GrowingLogFlagInfo   :
+                    os_log_info(logger, "%{public}s", msg);
+                    break;
+                case GrowingLogFlagDebug  :
+                case GrowingLogFlagVerbose:
+                default              :
+                    os_log_debug(logger, "%{public}s", msg);
+                    break;
+            }
+        }
+    }
+}
+
+@end


### PR DESCRIPTION
1. iOS 10+：ASLLogger 和 TTYLogger 同时使用会在 Xcode console 重复打印，建议使用 OSLogger 代替
https://github.com/CocoaLumberjack/CocoaLumberjack/issues/765
https://github.com/CocoaLumberjack/CocoaLumberjack/pull/850

2. 在 Debug 环境下，Simulator 调试日志无法在 console.app 查看，可在终端输入以下指令查看：
```Objective-C
xcrun simctl spawn booted log stream\
 --process Example\
 --level Debug\
 --predicate 'senderImagePath CONTAINS "GrowingAnalytics"'
```
> [Console app not showing info and debug logs](https://developer.apple.com/forums/thread/82736?answerId=422465022#422465022)
> [Using os_log and log streaming on iOS](https://www.iosdev.recipes/simulator/os_log/)

3. os_log/NSLog 1024 Bytes 截断问题暂时无法解决，在 console.app 显示日志将被截断，不影响 Xcode console
https://github.com/darlinghq/darling/blob/2e341e8c7c3ac5d0559ecbe2dd7dc64efa110bf4/src/libc/os/log.h#L225-L228