### PR TITLE
fix: SessionId 刷新、VISIT 事件发送与安卓 SDK 保持一致

### DIFF
--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -166,13 +166,12 @@ static GrowingEventManager *sharedInstance = nil;
             return;
         }
         
-        // 判断当前事件是否被过滤，否则不发送
-        if([GrowingEventFilter isFilterEvent:builder.eventType]){
+        if ([GrowingEventFilter isFilterEvent:builder.eventType]) {
             return;
         }
 
-        if (![GrowingSession currentSession].createdSession) {
-            [[GrowingSession currentSession] forceReissueVisit];
+        if (![GrowingSession currentSession].isSentVisitAfterRefreshSessionId) {
+            [[GrowingSession currentSession] generateVisit];
         }
 
         [builder readPropertyInTrackThread];

--- a/GrowingTrackerCore/GrowingTrackConfiguration.m
+++ b/GrowingTrackerCore/GrowingTrackConfiguration.m
@@ -68,7 +68,7 @@ NSString * const kGrowingDefaultDataCollectionServerHost = @"https://api.growing
     }
     _dataCollectionEnabled = dataCollectionEnabled;
     if (dataCollectionEnabled) {
-        [[GrowingSession currentSession] resendVisitEvent];
+        [[GrowingSession currentSession] generateVisit];
     }
 }
 

--- a/GrowingTrackerCore/Manager/GrowingSession.h
+++ b/GrowingTrackerCore/Manager/GrowingSession.h
@@ -19,39 +19,38 @@
 
 #import <Foundation/Foundation.h>
 
-
 @protocol GrowingUserIdChangedDelegate <NSObject>
+
 @required
 - (void)userIdDidChangedFrom:(NSString *)oldUserId to:(NSString *)newUserId;
+
 @end
 
 @interface GrowingSession : NSObject
-@property(nonatomic, copy, readonly) NSString *sessionId;
-@property(nonatomic, copy, readwrite) NSString *loginUserId;
-@property(nonatomic, copy, readwrite) NSString *loginUserKey;
-@property(nonatomic, assign, readonly) BOOL createdSession;
-@property(nonatomic, assign, readonly) double latitude;
-@property(nonatomic, assign, readonly) double longitude;
+
+@property (nonatomic, assign, readonly, getter=isSentVisitAfterRefreshSessionId) BOOL sentVisitAfterRefreshSessionId;
+@property (nonatomic, copy, readonly) NSString *sessionId;
+@property (nonatomic, copy, readonly) NSString *loginUserId;
+@property (nonatomic, copy, readonly) NSString *loginUserKey;
+@property (nonatomic, assign, readonly) double latitude;
+@property (nonatomic, assign, readonly) double longitude;
 
 + (void)startSession;
 
 + (instancetype)currentSession;
 
+- (void)generateVisit;
+
 - (void)addUserIdChangedDelegate:(id <GrowingUserIdChangedDelegate>)delegate;
 
 - (void)removeUserIdChangedDelegate:(id <GrowingUserIdChangedDelegate>)delegate;
 
-- (void)forceReissueVisit;
-
-- (void)resendVisitEvent;
-
-/// 设置经纬度坐标
-/// @param latitude 纬度
-/// @param longitude 经度
-- (void)setLocation:(double)latitude longitude:(double)longitude;
-/// 清除地理位置
-- (void)cleanLocation;
+- (void)setLoginUserId:(NSString *)loginUserId;
 
 - (void)setLoginUserId:(NSString *)loginUserId userKey:(NSString *)userKey;
+
+- (void)setLocation:(double)latitude longitude:(double)longitude;
+
+- (void)cleanLocation;
 
 @end

--- a/GrowingTrackerCore/Manager/GrowingSession.m
+++ b/GrowingTrackerCore/Manager/GrowingSession.m
@@ -107,6 +107,13 @@ static GrowingSession *currentSession = nil;
     }];
 }
 
+// 下拉显示通知中心/系统权限授权弹窗显示
+- (void)applicationWillResignActive {
+    [GrowingDispatchManager dispatchInGrowingThread:^{
+        self.latestDidEnterBackgroundTime = GrowingTimeUtil.currentTimeMillis;
+    }];
+}
+
 - (void)applicationDidEnterBackground {
     [GrowingDispatchManager dispatchInGrowingThread:^{
         self.latestDidEnterBackgroundTime = GrowingTimeUtil.currentTimeMillis;


### PR DESCRIPTION
- SessionId 刷新、VISIT 事件发送与安卓 SDK 保持一致
- 显示通知中心/系统权限授权弹窗显示应重新计算 backgroundTime

测试场景：https://github.com/growingio/growingio-sdk-ios-autotracker/pull/138#issue-715845960