### PR TITLE
fix: 线程资源紧张的情况下，VISIT 可能丢失

### DIFF
--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -67,6 +67,8 @@ const int GrowingTrackerVersionCode = 30201;
         [[GrowingEventManager sharedInstance] startTimerSend];
         [self versionPrint];
         [self filterLogPrint];
+        
+        [[GrowingSession currentSession] generateVisit];
     }
 
     return self;

--- a/GrowingTrackerCore/Manager/GrowingSession.m
+++ b/GrowingTrackerCore/Manager/GrowingSession.m
@@ -71,7 +71,6 @@ static GrowingSession *currentSession = nil;
     
     [GrowingAppLifecycle.sharedInstance addAppLifecycleDelegate:currentSession];
     [currentSession refreshSessionId];
-    [currentSession generateVisit];
 }
 
 + (instancetype)currentSession {


### PR DESCRIPTION
在线程资源紧张的情况下，GrowingEventManager 可能在主线程初始化（一般情况在 Growing Thread 中与事件创建串行），并在 主线程向 Growing Thread 注册数据库和事件队列的创建（`performSelector:OnThread:withObject:waitUntilDone:`），将导致 generateVisitEvent 函数调用时认为 GrowingEventManager 已创建且数据库配置等已完成。
注: 数据库配置等在 Growing Thread 线程执行是为了降低 SDK 初始化耗时。

未修改: 
------------------------------------------------------
线程资源紧张情况：
```Objective-C
  +[GrowingEventManager sharedInstance](Main Thread)->
  -[GrowingEventManager postEventBuidler:](Growing Thread, eventQueue = nil, send VISIT failure)->
  -[GrowingEventManager reloadFromDB_unsafe](Growing Thread, eventQueue = [])
```

正常情况：
```Objective-C
  +[GrowingEventManager sharedInstance](Growing Thread)->
  -[GrowingEventManager reloadFromDB_unsafe](Growing Thread, eventQueue = [])->
  -[GrowingEventManager postEventBuidler:](Growing Thread, eventQueue = [], send VISIT success)
```

修改后：
------------------------------------------------------
```Objective-C
  +[GrowingEventManager sharedInstance](Main Thread Or Growing Thread)->
  -[GrowingEventManager reloadFromDB_unsafe](Growing Thread, eventQueue = [])->
  -[GrowingEventManager postEventBuidler:](Growing Thread, eventQueue = [], send VISIT success)
```
