### PR TITLE
fix: 杀死进程 APP_CLOSED 未发送

### DIFF
--- a/GrowingTrackerCore/Event/GrowingEventManager.h
+++ b/GrowingTrackerCore/Event/GrowingEventManager.h
@@ -63,6 +63,9 @@
 /// 开启事件发送定时器
 - (void)startTimerSend;
 
+/// 事件入库
+- (void)flushDB;
+
 /// 发送event，必须在主线程调用
 /// @param builder event构造器
 - (void)postEventBuidler:(GrowingBaseBuilder *_Nullable)builder;

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -38,7 +38,6 @@
 #import "NSDictionary+GrowingHelper.h"
 #import "NSString+GrowingHelper.h"
 #import "GrowingEventFilter.h"
-#import "GrowingAppLifecycle.h"
 #import "GrowingEventNetworkService.h"
 #import "GrowingServiceManager.h"
 
@@ -49,7 +48,7 @@ static const NSUInteger kGrowingMaxBatchSize = 500;    // default: send no more 
 
 static const NSUInteger kGrowingUnit_MB = 1024 * 1024;
 
-@interface GrowingEventManager () <GrowingAppLifecycleDelegate>
+@interface GrowingEventManager ()
 
 @property (nonatomic, strong) NSHashTable *allInterceptor;
 @property (nonatomic, strong) NSLock *interceptorLock;
@@ -100,8 +99,6 @@ static GrowingEventManager *sharedInstance = nil;
             [self cleanExpiredData_unsafe];
             // load eventQueue for the first time
             [self reloadFromDB_unsafe];
-            
-            [[GrowingAppLifecycle sharedInstance] addAppLifecycleDelegate:self];
         }];
     }
     return self;
@@ -462,12 +459,6 @@ static GrowingEventManager *sharedInstance = nil;
     [self.interceptorLock lock];
     [self.allInterceptor removeObject:interceptor];
     [self.interceptorLock unlock];
-}
-
-#pragma mark - GrowingAppLifecycleDelegate
-
-- (void)applicationDidEnterBackground {
-    [self flushDB];
 }
 
 #pragma mark - Setter & Getter

--- a/GrowingTrackerCore/Thread/GrowingDispatchManager.h
+++ b/GrowingTrackerCore/Thread/GrowingDispatchManager.h
@@ -23,6 +23,8 @@
 
 + (void)dispatchInGrowingThread:(void (^_Nullable)(void))block;
 
++ (void)dispatchInGrowingThread:(void (^_Nullable)(void))block waitUntilDone:(BOOL)waitUntilDone;
+
 + (void)dispatchInMainThread:(void (^_Nullable)(void))block;
 
 + (void)dispatchInLowThread:(void (^_Nullable)(void))block;

--- a/GrowingTrackerCore/Thread/GrowingDispatchManager.m
+++ b/GrowingTrackerCore/Thread/GrowingDispatchManager.m
@@ -25,13 +25,17 @@
 @implementation GrowingDispatchManager
 
 + (void)dispatchInGrowingThread:(void (^_Nullable)(void))block {
+    [self dispatchInGrowingThread:block waitUntilDone:NO];
+}
+
++ (void)dispatchInGrowingThread:(void (^_Nullable)(void))block waitUntilDone:(BOOL)waitUntilDone {
     if ([[NSThread currentThread] isEqual:[GrowingThread sharedThread]]) {
         block();
     } else {
         [GrowingDispatchManager performSelector:@selector(dispatchBlock:)
                                        onThread:[GrowingThread sharedThread]
                                      withObject:block
-                                  waitUntilDone:NO];
+                                  waitUntilDone:waitUntilDone];
     }
 }
 


### PR DESCRIPTION
杀死进程时，Growing Thread 优先级较低，导致无法完成 APP_CLOSED 事件的入库，利用线程同步来确保事件 Build 及入库

### 问题：
是否需要使用 beginBackgroundTaskWithExpirationHandler<sup>[1]</sup> 函数确保进程前台切换至后台时，事件正常入库？
答：使用 B***u App 测试，目前使用线程同步确认的方式效果正常，暂不需要使用 beginBackgroundTaskWithExpirationHandler 函数来延长 Background 执行时间

### 测试时注意点：
1. debugEnabled 需为 NO，为 YES 则事件会立即入库，影响最终测试结果；
2. 断开数据线连接测试，连接调试的情况下，Watchdog<sup>[2]</sup> 机制无效；
3. 当进程处于 Suspended 状态下，杀死进程将不会收到 UIApplicationWillTerminateNotification<sup>[3]</sup> 通知；

### 参考：
*[1] [beginBackgroundTaskWithExpirationHandler](https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtaskwithexpiratio)*
*[2] [Watchdog maximum time is 10 sec for suspend state](https://stackoverflow.com/questions/59827727/ios-frequently-getting-exhausted-real-wall-clock-time-allowance-of-10-00-seco)*
*[3] [Respond to App-Based Life-Cycle Events](https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle#2928645)*