### PR TITLE
fix: cdp Interceptor 添加 gioId 失效

### DIFF
--- a/GrowingAutotracker/GrowingAutotracker.h
+++ b/GrowingAutotracker/GrowingAutotracker.h
@@ -19,7 +19,6 @@
 
 #import "GrowingDynamicProxy.h"
 #import "GrowingAutotrackConfiguration.h"
-#import "GrowingRealAutotracker.h"
 #import <UIKit/UIKit.h>
 
 @interface GrowingAutotracker : GrowingDynamicProxy

--- a/GrowingAutotracker/GrowingAutotracker.m
+++ b/GrowingAutotracker/GrowingAutotracker.m
@@ -18,6 +18,7 @@
 //  limitations under the License.
 
 #import "GrowingAutotracker.h"
+#import "GrowingSession.h"
 #import "GrowingLogMacros.h"
 #import "GrowingLogger.h"
 
@@ -45,6 +46,7 @@ static GrowingAutotracker *sharedInstance = nil;
     dispatch_once(&onceToken, ^{
         GrowingRealAutotracker *autotracker = [GrowingRealAutotracker trackerWithConfiguration:configuration launchOptions:launchOptions];
         sharedInstance = [[self alloc] initWithRealAutotracker:autotracker];
+        [[GrowingSession currentSession] generateVisit];
     });
 }
 

--- a/GrowingAutotracker/GrowingAutotracker.m
+++ b/GrowingAutotracker/GrowingAutotracker.m
@@ -18,6 +18,7 @@
 //  limitations under the License.
 
 #import "GrowingAutotracker.h"
+#import "GrowingRealAutotracker.h"
 #import "GrowingSession.h"
 #import "GrowingLogMacros.h"
 #import "GrowingLogger.h"

--- a/GrowingAutotrackerCore/GrowingAutotrackConfiguration.h
+++ b/GrowingAutotrackerCore/GrowingAutotrackConfiguration.h
@@ -22,6 +22,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, GrowingIgnorePolicy) {
+    GrowingIgnoreNone = 0,
+    GrowingIgnoreSelf = 1,     // 忽略自身
+    GrowingIgnoreChildren = 2, // 忽略所有子页面和孙子页面
+    GrowingIgnoreAll = 3,      // 忽略自身 + 忽略所有子页面和孙子页面
+};
+
 @interface GrowingAutotrackConfiguration : GrowingTrackConfiguration
 
 @property(nonatomic, assign) float impressionScale;

--- a/GrowingAutotrackerCore/GrowingAutotrackConfiguration.m
+++ b/GrowingAutotrackerCore/GrowingAutotrackConfiguration.m
@@ -20,7 +20,6 @@
 
 #import "GrowingAutotrackConfiguration.h"
 
-
 @implementation GrowingAutotrackConfiguration
 
 - (id)copyWithZone:(NSZone *)zone {

--- a/GrowingAutotrackerCore/GrowingNode/Category/UIView+GrowingNode.m
+++ b/GrowingAutotrackerCore/GrowingNode/Category/UIView+GrowingNode.m
@@ -31,7 +31,6 @@
 #import "UIView+GrowingNode.h"
 #import "GrowingImpressionTrack.h"
 #import "GrowingConfigurationManager.h"
-#import "GrowingRealAutotracker.h"
 #import "GrowingNode.h"
 #import "GrowingAutotrackConfiguration.h"
 

--- a/GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.h
+++ b/GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.h
@@ -19,7 +19,6 @@
 
 
 #import <UIKit/UIKit.h>
-#import "GrowingRealAutotracker.h"
 #import "GrowingNodeProtocol.h"
 
 @interface UIViewController (GrowingNode) <GrowingNode>
@@ -27,7 +26,6 @@
 @end
 
 @interface UIViewController (GrowingPrivateAttributes)
-
 
 - (void)mergeGrowingAttributesPvar:(NSDictionary<NSString *,NSObject *> *)growingAttributesPvar;
 - (void)removeGrowingAttributesPvar:(NSString *)key;

--- a/GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.m
+++ b/GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.m
@@ -23,7 +23,7 @@
 #import "GrowingPageManager.h"
 #import "GrowingPrivateCategory.h"
 #import "GrowingPropertyDefine.h"
-#import "GrowingRealAutotracker.h"
+#import "GrowingAutotrackConfiguration.h"
 #import "NSDictionary+GrowingHelper.h"
 #import "NSObject+GrowingIvarHelper.h"
 #import "UIApplication+GrowingNode.h"

--- a/GrowingAutotrackerCore/GrowingRealAutotracker.h
+++ b/GrowingAutotrackerCore/GrowingRealAutotracker.h
@@ -20,13 +20,6 @@
 #import <Foundation/Foundation.h>
 #import "GrowingRealTracker.h"
 
-typedef NS_ENUM(NSUInteger, GrowingIgnorePolicy) {
-    GrowingIgnoreNone = 0,
-    GrowingIgnoreSelf = 1,     // 忽略自身
-    GrowingIgnoreChildren = 2, // 忽略所有子页面和孙子页面
-    GrowingIgnoreAll = 3,      // 忽略自身 + 忽略所有子页面和孙子页面
-};
-
 @interface GrowingRealAutotracker : GrowingRealTracker
 
 @end

--- a/GrowingAutotrackerCore/GrowingRealAutotracker.m
+++ b/GrowingAutotrackerCore/GrowingRealAutotracker.m
@@ -38,6 +38,7 @@
 #import "GrowingNetworkConfig.h"
 
 @implementation GrowingRealAutotracker
+
 - (instancetype)initWithConfiguration:(GrowingTrackConfiguration *)configuration launchOptions:(NSDictionary *)launchOptions {
     self = [super initWithConfiguration:configuration launchOptions:launchOptions];
     if (self) {

--- a/GrowingAutotrackerCore/Page/UIViewController+GrowingPageHelper.m
+++ b/GrowingAutotrackerCore/Page/UIViewController+GrowingPageHelper.m
@@ -22,8 +22,9 @@
 #import "UIViewController+GrowingPageHelper.h"
 #import "UIViewController+GrowingNode.h"
 #import "GrowingPage.h"
-#import "GrowingRealAutotracker.h"
+#import "GrowingAutotrackConfiguration.h"
 #import "GrowingPrivateCategory.h"
+
 static void *const GROWING_PAGE_OBJECT = "GROWING_PAGE_OBJECT";
 
 @implementation UIViewController (GrowingPageHelper)

--- a/GrowingAutotrackerCore/Private/GrowingPrivateCategory.h
+++ b/GrowingAutotrackerCore/Private/GrowingPrivateCategory.h
@@ -19,8 +19,7 @@
 
 //用于AutotrackerCore中引入分类，而这些分类属性对于不同的模块，是可选的
 #import <UIKit/UIKit.h>
-
-#import "GrowingRealAutotracker.h"
+#import "GrowingAutotrackConfiguration.h"
 
 // 该属性setter方法均使用 objc_setAssociatedObject实现
 // 如果是自定义的View建议优先使用重写getter方法来实现 以提高性能

--- a/GrowingTracker/GrowingTracker.h
+++ b/GrowingTracker/GrowingTracker.h
@@ -20,7 +20,6 @@
 #import "GrowingDynamicProxy.h"
 #import "GrowingTrackConfiguration.h"
 
-
 @interface GrowingTracker : GrowingDynamicProxy
 
 /// 初始化方法

--- a/GrowingTracker/GrowingTracker.m
+++ b/GrowingTracker/GrowingTracker.m
@@ -16,10 +16,10 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+
 #import "GrowingTracker.h"
-#import "GrowingTrackConfiguration.h"
-#import "GrowingTrackConfiguration.h"
 #import "GrowingRealTracker.h"
+#import "GrowingSession.h"
 #import "GrowingLogMacros.h"
 #import "GrowingLogger.h"
 
@@ -47,6 +47,7 @@ static GrowingTracker *sharedInstance = nil;
     dispatch_once(&onceToken, ^{
         GrowingRealTracker *realTracker = [GrowingRealTracker trackerWithConfiguration:configuration launchOptions:launchOptions];
         sharedInstance = [[self alloc] initWithRealTracker:realTracker];
+        [[GrowingSession currentSession] generateVisit];
     });
 }
 

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -67,8 +67,6 @@ const int GrowingTrackerVersionCode = 30201;
         [[GrowingEventManager sharedInstance] startTimerSend];
         [self versionPrint];
         [self filterLogPrint];
-        
-        [[GrowingSession currentSession] generateVisit];
     }
 
     return self;

--- a/Modules/WebCircle/GrowingWebCircle.m
+++ b/Modules/WebCircle/GrowingWebCircle.m
@@ -59,6 +59,7 @@
 #import "GrowingServiceManager.h"
 #import "GrowingHybridBridgeProvider.h"
 #import "GrowingWebSocketService.h"
+#import "GrowingRealTracker.h"
 
 @GrowingMod(GrowingWebCircle)
 


### PR DESCRIPTION
cdp 在 trackerWithConfiguration:launchOptions: 函数之后才添加的拦截器，用于userId 改变时持久化 gioId 以及发数前添加 gioId；
generateVisit 时机早于拦截器，将使 gioId 未附带上传。

### 测试
cdp 初始化 SDK 后首次发送的 VISIT 事件附带的 gioId、dataSourceId 是否正常。