### PR TITLE
fix: WebView Bridge 注入延后至 loadRequest:

### DIFF
--- a/GrowingAutotrackerCore/GrowingNode/Category/UIView+GrowingNode.h
+++ b/GrowingAutotrackerCore/GrowingNode/Category/UIView+GrowingNode.h
@@ -31,6 +31,7 @@
 @property (nonatomic, copy) NSString *growingUniqueTag;
 - (BOOL)growingViewUserInteraction;
 - (NSString *)growingViewContent;
+- (BOOL)growingViewDontTrack;
 
 @end
 

--- a/Modules/Hybrid/GrowingHybridModule.m
+++ b/Modules/Hybrid/GrowingHybridModule.m
@@ -36,11 +36,36 @@
     dispatch_once(&onceToken, ^{
         // WKWebView
         NSError *webViewError = NULL;
-        [WKWebView growing_swizzleMethod:@selector(initWithFrame:configuration:)
-                              withMethod:@selector(growing_initWithFrame:configuration:)
+        [WKWebView growing_swizzleMethod:@selector(loadRequest:)
+                              withMethod:@selector(growing_loadRequest:)
                                    error:&webViewError];
         if (webViewError) {
-            GIOLogError(@"Failed to swizzle WKWebView. Details: %@", webViewError);
+            GIOLogError(@"Failed to swizzle WKWebView loadRequest:. Details: %@", webViewError);
+            webViewError = NULL;
+        }
+        
+        [WKWebView growing_swizzleMethod:@selector(loadHTMLString:baseURL:)
+                              withMethod:@selector(growing_loadHTMLString:baseURL:)
+                                   error:&webViewError];
+        if (webViewError) {
+            GIOLogError(@"Failed to swizzle WKWebView loadHTMLString:baseURL:. Details: %@", webViewError);
+            webViewError = NULL;
+        }
+        
+        [WKWebView growing_swizzleMethod:@selector(loadFileURL:allowingReadAccessToURL:)
+                              withMethod:@selector(growing_loadFileURL:allowingReadAccessToURL:)
+                                   error:&webViewError];
+        if (webViewError) {
+            GIOLogError(@"Failed to swizzle WKWebView loadFileURL:allowingReadAccessToURL:. Details: %@", webViewError);
+            webViewError = NULL;
+        }
+        
+        [WKWebView growing_swizzleMethod:@selector(loadData:MIMEType:characterEncodingName:baseURL:)
+                              withMethod:@selector(growing_loadData:MIMEType:characterEncodingName:baseURL:)
+                                   error:&webViewError];
+        if (webViewError) {
+            GIOLogError(@"Failed to swizzle WKWebView loadData:MIMEType:characterEncodingName:baseURL:. Details: %@", webViewError);
+            webViewError = NULL;
         }
     });
 }

--- a/Modules/Hybrid/GrowingWKWebViewJavascriptBridge.h
+++ b/Modules/Hybrid/GrowingWKWebViewJavascriptBridge.h
@@ -21,7 +21,8 @@
 
 @class WKWebView;
 
-
 @interface GrowingWKWebViewJavascriptBridge : NSObject
+
 + (void)bridgeForWebView:(WKWebView *)webView;
+
 @end

--- a/Modules/Hybrid/WKWebView+GrowingAutotracker.h
+++ b/Modules/Hybrid/WKWebView+GrowingAutotracker.h
@@ -17,14 +17,16 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
 #import <WebKit/WebKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WKWebView (GrowingAutotracker)
 
-- (instancetype)growing_initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration;
+- (WKNavigation *)growing_loadRequest:(NSURLRequest *)request;
+- (WKNavigation *)growing_loadHTMLString:(NSString *)string baseURL:(NSURL *)baseURL;
+- (WKNavigation *)growing_loadFileURL:(NSURL *)URL allowingReadAccessToURL:(NSURL *)readAccessURL;
+- (WKNavigation *)growing_loadData:(NSData *)data MIMEType:(NSString *)MIMEType characterEncodingName:(NSString *)characterEncodingName baseURL:(NSURL *)baseURL;
 
 @end
 

--- a/Modules/Hybrid/WKWebView+GrowingAutotracker.m
+++ b/Modules/Hybrid/WKWebView+GrowingAutotracker.m
@@ -17,16 +17,29 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
 #import "WKWebView+GrowingAutotracker.h"
 #import "GrowingWKWebViewJavascriptBridge.h"
 
 @implementation WKWebView (GrowingAutotracker)
 
-- (instancetype)growing_initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration {
-    __strong WKWebView *wkWebView = [self growing_initWithFrame:frame configuration:configuration];
-    [GrowingWKWebViewJavascriptBridge bridgeForWebView:wkWebView];
-    return wkWebView;
+- (WKNavigation *)growing_loadRequest:(NSURLRequest *)request {
+    [GrowingWKWebViewJavascriptBridge bridgeForWebView:self];
+    return [self growing_loadRequest:request];
+}
+
+- (WKNavigation *)growing_loadHTMLString:(NSString *)string baseURL:(NSURL *)baseURL {
+    [GrowingWKWebViewJavascriptBridge bridgeForWebView:self];
+    return [self growing_loadHTMLString:string baseURL:baseURL];
+}
+
+- (WKNavigation *)growing_loadFileURL:(NSURL *)URL allowingReadAccessToURL:(NSURL *)readAccessURL {
+    [GrowingWKWebViewJavascriptBridge bridgeForWebView:self];
+    return [self growing_loadFileURL:URL allowingReadAccessToURL:readAccessURL];
+}
+
+- (WKNavigation *)growing_loadData:(NSData *)data MIMEType:(NSString *)MIMEType characterEncodingName:(NSString *)characterEncodingName baseURL:(NSURL *)baseURL {
+    [GrowingWKWebViewJavascriptBridge bridgeForWebView:self];
+    return [self growing_loadData:data MIMEType:MIMEType characterEncodingName:characterEncodingName baseURL:baseURL];
 }
 
 @end


### PR DESCRIPTION
### 背景
可通过配置`webView.growingViewIgnorePolicy`来控制是否注入 WebView Bridge

### 调整内容
1. WebView Bridge 注入延后至`loadRequest`等函数
2. GrowingWKWebViewJavascriptBridge 调整为**单例**
3. 使用`webView.growingViewDontTrack`判断 webView 是否可 track，`webView.growingNodeDonotTrack`中`webView.window`在更新界面之前会返回 nil
```Objective-C
- (void)viewDidLoad {
    [super viewDidLoad];

    WKWebView *webView = ...
    NSURLRequest *request = ...
    [self.view addSubview:webView];
    [webView loadRequest:request]; // 此时 webView.window = nil
}
```

### 测试
1. 设置`webView.growingViewIgnorePolicy = GrowingIgnoreSelf` 或 `webView.growingViewIgnorePolicy = GrowingIgnoreAll`，测试 webView 是否发送埋点事件；
2. 设置`webView.growingViewIgnorePolicy = GrowingIgnoreNone` 或 `webView.growingViewIgnorePolicy = GrowingIgnoreChildren`，测试 webView 是否发送埋点事件；
3. 设置 `webView.superview.growingViewIgnorePolicy = GrowingIgnoreChildren` 或 `webView.superview.growingViewIgnorePolicy = GrowingIgnoreAll`，测试 webView 是否发送埋点事件；
4. 多次调用 loadRequest: 等函数，使用 Safari 调试器查看 userScript 脚本列表，测试是否重复注入；

### 预期结果
1. 不发送埋点事件
2. 发送埋点事件
3. 不发送埋点事件
4. 不会重复注入