### PR TITLE
feat: 新增 version 相关接口 (Private)，提供给 GrowingToolsKit 调用

### DIFF
--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -102,6 +102,16 @@ const int GrowingTrackerVersionCode = 30202;
     GIOLogInfo(@"%@", versionStr);
 }
 
++ (NSString *)versionName {
+    // give support to GrowingToolsKit
+    return [NSString stringWithFormat:@"%@", GrowingTrackerVersionName];
+}
+
++ (NSString *)versionCode {
+    // give support to GrowingToolsKit
+    return [NSString stringWithFormat:@"%d", GrowingTrackerVersionCode];
+}
+
 - (void)filterLogPrint {
     if(GrowingConfigurationManager.sharedInstance.trackConfiguration.excludeEvent > 0) {
         GIOLogInfo(@"%@", [GrowingEventFilter getFilterEventLog]);


### PR DESCRIPTION
插件可通过配置 podspec
```Ruby
s.pod_target_xcconfig = { 'OTHER_LDFLAGS => -Wl,-U,_GrowingTrackerVersionName' }
```
之后，再在具体实现中
```Objective-C
extern NSString *const GrowingTrackerVersionName;
```
来获取值。

但这种方式无法与 ENABLE_BITCODE 兼容
```
ld: -U and -bitcode_bundle (Xcode setting ENABLE_BITCODE=YES) cannot be used together
```

出于插件的集成尽量不改变宿主工程配置考虑，使用另一种方案：SDK 中添加 version 获取相关实现，插件中使用反射或 Objective-C Runtime 来获取。