### PR TITLE
feat: 适配flutter无埋点

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.4.8](https://github.com/growingio/growingio-sdk-ios-autotracker/compare/3.4.7...3.4.8) (2023-03-31)
+
+### Features
+
+* 支持 Flutter 无埋点 SDK ([ceb94e5](https://github.com/growingio/growingio-sdk-ios-autotracker/commit/ceb94e5c8684d68c1e196341f0755766993b6e73))
+
 ## [3.4.7](https://github.com/growingio/growingio-sdk-ios-autotracker/compare/3.4.6...3.4.7) (2023-02-23)
 
 ### Bug Fixes

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		0089C2BFC7A6217241A07E0A /* Pods_HostApplicationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48FE15120F9DB1ACB92044FC /* Pods_HostApplicationTests.framework */; };
 		0465313624DD4272002D254C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 046530D124DD4271002D254C /* Assets.xcassets */; };
 		0465313724DD4272002D254C /* GIODataProcessOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 046530D324DD4271002D254C /* GIODataProcessOperation.m */; };
 		0465313924DD4272002D254C /* GIOConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 046530D724DD4271002D254C /* GIOConstants.m */; };
@@ -76,6 +75,7 @@
 		04A6FAF224E662E9006C72F0 /* GIOChildsAddViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A6FAF124E662E9006C72F0 /* GIOChildsAddViewController.m */; };
 		04A6FAF524E67215006C72F0 /* GIOBaseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A6FAF424E67215006C72F0 /* GIOBaseViewController.m */; };
 		04F675662628293800077374 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04F675652628293800077374 /* AdSupport.framework */; };
+		2706AC28FE1FD39A2E459F61 /* Pods_AdvertTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AF3F27899C8B5AB4B7F28FC /* Pods_AdvertTests.framework */; };
 		2B94D97E1142050DE05C4480 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E4D4EB10715BBF33936F7BC /* Pods_Example.framework */; };
 		34106BB428FECB0E00E7DB01 /* Crasher.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34106BB328FECB0E00E7DB01 /* Crasher.mm */; };
 		34486D3D27B1049000FA8223 /* UITapGestureRecognizerAutotrackTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 34486D3B27B102B000FA8223 /* UITapGestureRecognizerAutotrackTest.m */; };
@@ -163,18 +163,18 @@
 		34C0BF3D277EA9BA0047ADC4 /* MobileDebuggerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 34C0BF3C277EA9BA0047ADC4 /* MobileDebuggerTest.m */; };
 		34D932FE27BF8C640038430E /* MockEventQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 4962653324DA66B600032551 /* MockEventQueue.m */; };
 		34D9330027BF943F0038430E /* A0GrowingAnalyticsCDPTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 34D932F927BF8A400038430E /* A0GrowingAnalyticsCDPTest.m */; };
-		4676881438BA21E27C4F684A /* Pods_GrowingAnalyticsCDPTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20F052195F946572FF10B9DF /* Pods_GrowingAnalyticsCDPTests.framework */; };
+		3A4EC756173A7F4ADE8DE52E /* Pods_GrowingAnalyticsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3318B06C51540C267A7A1743 /* Pods_GrowingAnalyticsTests.framework */; };
+		3ED9537CC610D6665D8CFD8D /* Pods_ExampleiOS13.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 930C87616165A36AA7754D13 /* Pods_ExampleiOS13.framework */; };
 		4916270F24E157BB00444AF2 /* GIOPresentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4916270E24E157BB00444AF2 /* GIOPresentViewController.m */; };
 		4916271224E157CF00444AF2 /* GIOPagingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4916271124E157CF00444AF2 /* GIOPagingViewController.m */; };
 		491D2D8D2500E2D9001CB289 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 491D2D8C2500E2D9001CB289 /* MapKit.framework */; };
-		4BAD0C268E718779953D420E /* Pods_ExampleiOS13.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC2036F16A91796927E923E5 /* Pods_ExampleiOS13.framework */; };
-		51EFDAC79C29C4FF3ED6D77E /* Pods_GrowingAnalyticsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A131AD28D173A2BB6CBF9C8 /* Pods_GrowingAnalyticsTests.framework */; };
+		558A8A290D280B135DAFBA62 /* Pods_HostApplicationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0EFF6A27D438C999039D96A /* Pods_HostApplicationTests.framework */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
-		9163E777CF42D5727BA71B4F /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1676945A2B2799A168DE8CE /* Pods_GrowingAnalyticsStartTests.framework */; };
-		D30B3E0F1990278E593AADB3 /* Pods_AdvertTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3207E4CA6A3865A7B1C3ACA /* Pods_AdvertTests.framework */; };
-		DC4E9FAD2CDF39E22390DAFA /* Pods_ProtobufTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042ADE8D7A6EB0FAF1C06697 /* Pods_ProtobufTests.framework */; };
+		A6888BD241EEBA183D8B5C2F /* Pods_ProtobufTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 119695ADD5703B43BC026419 /* Pods_ProtobufTests.framework */; };
+		D7606806545268BFFF1D6174 /* Pods_GrowingAnalyticsCDPTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79E4CF8FB42177E30083930D /* Pods_GrowingAnalyticsCDPTests.framework */; };
+		E3B1B3B5BA77BF7196126B40 /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 644C1C0BF22783F3EC8D7262 /* Pods_GrowingAnalyticsStartTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -202,7 +202,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		042ADE8D7A6EB0FAF1C06697 /* Pods_ProtobufTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProtobufTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		046530BD24DD4271002D254C /* GrowingIO-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GrowingIO-Prefix.pch"; sourceTree = "<group>"; };
 		046530BE24DD4271002D254C /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		046530D124DD4271002D254C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -294,13 +293,11 @@
 		04A6FAF424E67215006C72F0 /* GIOBaseViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GIOBaseViewController.m; sourceTree = "<group>"; };
 		04AEA7E5277319E300ED6CC8 /* GrowingDispatchManagerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GrowingDispatchManagerTest.m; sourceTree = "<group>"; };
 		04F675652628293800077374 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
-		0784CB0FF505AC3ED0EC508C /* Pods-HostApplicationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.release.xcconfig"; sourceTree = "<group>"; };
-		0A131AD28D173A2BB6CBF9C8 /* Pods_GrowingAnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B9B66FA65EE5170181EDDA0 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
-		20F052195F946572FF10B9DF /* Pods_GrowingAnalyticsCDPTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsCDPTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2B362FDA6F298488AE09B02E /* Pods-ProtobufTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.debug.xcconfig"; path = "Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.debug.xcconfig"; sourceTree = "<group>"; };
-		2DCB860F6F7A79016D3E103E /* Pods-ExampleiOS13.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.debug.xcconfig"; path = "Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.debug.xcconfig"; sourceTree = "<group>"; };
-		322A0137D291314D9DA5617A /* Pods-AdvertTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertTests.debug.xcconfig"; path = "Target Support Files/Pods-AdvertTests/Pods-AdvertTests.debug.xcconfig"; sourceTree = "<group>"; };
+		119695ADD5703B43BC026419 /* Pods_ProtobufTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProtobufTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		15B6BB849F26AF0791371D18 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsCDPTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests.release.xcconfig"; sourceTree = "<group>"; };
+		1AF3F27899C8B5AB4B7F28FC /* Pods_AdvertTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdvertTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3318B06C51540C267A7A1743 /* Pods_GrowingAnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		34106BB228FECB0D00E7DB01 /* Crasher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Crasher.h; sourceTree = "<group>"; };
 		34106BB328FECB0E00E7DB01 /* Crasher.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Crasher.mm; sourceTree = "<group>"; };
 		34486D3B27B102B000FA8223 /* UITapGestureRecognizerAutotrackTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UITapGestureRecognizerAutotrackTest.m; sourceTree = "<group>"; };
@@ -385,10 +382,7 @@
 		34C0BF3C277EA9BA0047ADC4 /* MobileDebuggerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MobileDebuggerTest.m; sourceTree = "<group>"; };
 		34D932F727BF8A400038430E /* GrowingAnalyticsCDPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GrowingAnalyticsCDPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		34D932F927BF8A400038430E /* A0GrowingAnalyticsCDPTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = A0GrowingAnalyticsCDPTest.m; sourceTree = "<group>"; };
-		3F38C7B6F4B9AA66D1C43C12 /* Pods-AdvertTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertTests.release.xcconfig"; path = "Target Support Files/Pods-AdvertTests/Pods-AdvertTests.release.xcconfig"; sourceTree = "<group>"; };
-		3F5E5E2D15AE01361CEF96EA /* Pods-ExampleiOS13.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.release.xcconfig"; path = "Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.release.xcconfig"; sourceTree = "<group>"; };
 		42ADE26B250B292900CA7268 /* HybridTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HybridTest.m; sourceTree = "<group>"; };
-		48FE15120F9DB1ACB92044FC /* Pods_HostApplicationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApplicationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4916270D24E157BB00444AF2 /* GIOPresentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GIOPresentViewController.h; sourceTree = "<group>"; };
 		4916270E24E157BB00444AF2 /* GIOPresentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GIOPresentViewController.m; sourceTree = "<group>"; };
 		4916271024E157CF00444AF2 /* GIOPagingViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GIOPagingViewController.h; sourceTree = "<group>"; };
@@ -398,24 +392,30 @@
 		4962653224DA66B600032551 /* ManualTrackHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ManualTrackHelper.m; sourceTree = "<group>"; };
 		4962653324DA66B600032551 /* MockEventQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockEventQueue.m; sourceTree = "<group>"; };
 		4962653824DA66B600032551 /* ManualTrackHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ManualTrackHelper.h; sourceTree = "<group>"; };
-		581FA43E281E2C470D4AAFCD /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsCDPTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5A726A5206E26820EAE1C12C /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		6003F591195388D20070C39A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		70A32BBD6417C9BF035F83C8 /* Pods-HostApplicationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.debug.xcconfig"; sourceTree = "<group>"; };
+		60F77CA47D760F5DDE8FFF21 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsStartTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests.debug.xcconfig"; sourceTree = "<group>"; };
+		644C1C0BF22783F3EC8D7262 /* Pods_GrowingAnalyticsStartTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsStartTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		667FE81378C014039802CB22 /* Pods-ProtobufTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.debug.xcconfig"; path = "Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.debug.xcconfig"; sourceTree = "<group>"; };
+		75A09303FD32EECF0AD4EA4D /* Pods-HostApplicationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.debug.xcconfig"; sourceTree = "<group>"; };
+		79E4CF8FB42177E30083930D /* Pods_GrowingAnalyticsCDPTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsCDPTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E4D4EB10715BBF33936F7BC /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A629672AAF8632F7C9C229BB /* Pods-GrowingAnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
-		AC2036F16A91796927E923E5 /* Pods_ExampleiOS13.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleiOS13.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B3207E4CA6A3865A7B1C3ACA /* Pods_AdvertTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdvertTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B53CE07A26B1CF805C783A2F /* Pods-GrowingAnalyticsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.release.xcconfig"; sourceTree = "<group>"; };
-		C72223C1736A45B1E50A6BD3 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsCDPTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests.release.xcconfig"; sourceTree = "<group>"; };
-		D01B4845722C332D8F8D39C3 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsStartTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests.release.xcconfig"; sourceTree = "<group>"; };
-		E1676945A2B2799A168DE8CE /* Pods_GrowingAnalyticsStartTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsStartTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E381BC17741A543E72DCA2B2 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsStartTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests.debug.xcconfig"; sourceTree = "<group>"; };
-		FD5D59B9A176A76AB87F5674 /* Pods-ProtobufTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.release.xcconfig"; path = "Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.release.xcconfig"; sourceTree = "<group>"; };
+		930C87616165A36AA7754D13 /* Pods_ExampleiOS13.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleiOS13.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		971A522EDA0D265E607070FB /* Pods-ProtobufTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.release.xcconfig"; path = "Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.release.xcconfig"; sourceTree = "<group>"; };
+		B1A467B42E507DB2C5BF7A46 /* Pods-ExampleiOS13.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.release.xcconfig"; path = "Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.release.xcconfig"; sourceTree = "<group>"; };
+		B1B0E469D2F9EA36A787D5E7 /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsCDPTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests.debug.xcconfig"; sourceTree = "<group>"; };
+		BE3D8AD215D13B387143219B /* Pods-AdvertTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertTests.release.xcconfig"; path = "Target Support Files/Pods-AdvertTests/Pods-AdvertTests.release.xcconfig"; sourceTree = "<group>"; };
+		C0EFF6A27D438C999039D96A /* Pods_HostApplicationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApplicationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6CF7AED52273FB42287E823 /* Pods-HostApplicationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.release.xcconfig"; sourceTree = "<group>"; };
+		E1FAB1B410063271250FFC6D /* Pods-AdvertTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertTests.debug.xcconfig"; path = "Target Support Files/Pods-AdvertTests/Pods-AdvertTests.debug.xcconfig"; sourceTree = "<group>"; };
+		EF77207AC05D4702F8C9C58C /* Pods-ExampleiOS13.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.debug.xcconfig"; path = "Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.debug.xcconfig"; sourceTree = "<group>"; };
+		F274DEF2F4ECD48426EFD4DA /* Pods-GrowingAnalyticsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.release.xcconfig"; sourceTree = "<group>"; };
+		F286A03FF69374A3647F1EE3 /* Pods-GrowingAnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FBC4514B8EC1B458F43C9820 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsStartTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -432,7 +432,7 @@
 			files = (
 				349975FB28BF303100466640 /* iAd.framework in Frameworks */,
 				349975FC28BF303B00466640 /* AdServices.framework in Frameworks */,
-				4BAD0C268E718779953D420E /* Pods_ExampleiOS13.framework in Frameworks */,
+				3ED9537CC610D6665D8CFD8D /* Pods_ExampleiOS13.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,7 +447,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D30B3E0F1990278E593AADB3 /* Pods_AdvertTests.framework in Frameworks */,
+				2706AC28FE1FD39A2E459F61 /* Pods_AdvertTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -455,7 +455,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9163E777CF42D5727BA71B4F /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */,
+				E3B1B3B5BA77BF7196126B40 /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -463,7 +463,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51EFDAC79C29C4FF3ED6D77E /* Pods_GrowingAnalyticsTests.framework in Frameworks */,
+				3A4EC756173A7F4ADE8DE52E /* Pods_GrowingAnalyticsTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -471,7 +471,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DC4E9FAD2CDF39E22390DAFA /* Pods_ProtobufTests.framework in Frameworks */,
+				A6888BD241EEBA183D8B5C2F /* Pods_ProtobufTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -479,7 +479,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0089C2BFC7A6217241A07E0A /* Pods_HostApplicationTests.framework in Frameworks */,
+				558A8A290D280B135DAFBA62 /* Pods_HostApplicationTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -487,7 +487,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4676881438BA21E27C4F684A /* Pods_GrowingAnalyticsCDPTests.framework in Frameworks */,
+				D7606806545268BFFF1D6174 /* Pods_GrowingAnalyticsCDPTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1262,14 +1262,14 @@
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				B3207E4CA6A3865A7B1C3ACA /* Pods_AdvertTests.framework */,
 				7E4D4EB10715BBF33936F7BC /* Pods_Example.framework */,
-				AC2036F16A91796927E923E5 /* Pods_ExampleiOS13.framework */,
-				20F052195F946572FF10B9DF /* Pods_GrowingAnalyticsCDPTests.framework */,
-				E1676945A2B2799A168DE8CE /* Pods_GrowingAnalyticsStartTests.framework */,
-				0A131AD28D173A2BB6CBF9C8 /* Pods_GrowingAnalyticsTests.framework */,
-				48FE15120F9DB1ACB92044FC /* Pods_HostApplicationTests.framework */,
-				042ADE8D7A6EB0FAF1C06697 /* Pods_ProtobufTests.framework */,
+				1AF3F27899C8B5AB4B7F28FC /* Pods_AdvertTests.framework */,
+				930C87616165A36AA7754D13 /* Pods_ExampleiOS13.framework */,
+				79E4CF8FB42177E30083930D /* Pods_GrowingAnalyticsCDPTests.framework */,
+				644C1C0BF22783F3EC8D7262 /* Pods_GrowingAnalyticsStartTests.framework */,
+				3318B06C51540C267A7A1743 /* Pods_GrowingAnalyticsTests.framework */,
+				C0EFF6A27D438C999039D96A /* Pods_HostApplicationTests.framework */,
+				119695ADD5703B43BC026419 /* Pods_ProtobufTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1277,22 +1277,22 @@
 		6E06FB7C2AABE327D97FC29F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				322A0137D291314D9DA5617A /* Pods-AdvertTests.debug.xcconfig */,
-				3F38C7B6F4B9AA66D1C43C12 /* Pods-AdvertTests.release.xcconfig */,
 				0B9B66FA65EE5170181EDDA0 /* Pods-Example.debug.xcconfig */,
 				5A726A5206E26820EAE1C12C /* Pods-Example.release.xcconfig */,
-				2DCB860F6F7A79016D3E103E /* Pods-ExampleiOS13.debug.xcconfig */,
-				3F5E5E2D15AE01361CEF96EA /* Pods-ExampleiOS13.release.xcconfig */,
-				581FA43E281E2C470D4AAFCD /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */,
-				C72223C1736A45B1E50A6BD3 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */,
-				E381BC17741A543E72DCA2B2 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */,
-				D01B4845722C332D8F8D39C3 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */,
-				A629672AAF8632F7C9C229BB /* Pods-GrowingAnalyticsTests.debug.xcconfig */,
-				B53CE07A26B1CF805C783A2F /* Pods-GrowingAnalyticsTests.release.xcconfig */,
-				70A32BBD6417C9BF035F83C8 /* Pods-HostApplicationTests.debug.xcconfig */,
-				0784CB0FF505AC3ED0EC508C /* Pods-HostApplicationTests.release.xcconfig */,
-				2B362FDA6F298488AE09B02E /* Pods-ProtobufTests.debug.xcconfig */,
-				FD5D59B9A176A76AB87F5674 /* Pods-ProtobufTests.release.xcconfig */,
+				E1FAB1B410063271250FFC6D /* Pods-AdvertTests.debug.xcconfig */,
+				BE3D8AD215D13B387143219B /* Pods-AdvertTests.release.xcconfig */,
+				EF77207AC05D4702F8C9C58C /* Pods-ExampleiOS13.debug.xcconfig */,
+				B1A467B42E507DB2C5BF7A46 /* Pods-ExampleiOS13.release.xcconfig */,
+				B1B0E469D2F9EA36A787D5E7 /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */,
+				15B6BB849F26AF0791371D18 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */,
+				60F77CA47D760F5DDE8FFF21 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */,
+				FBC4514B8EC1B458F43C9820 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */,
+				F286A03FF69374A3647F1EE3 /* Pods-GrowingAnalyticsTests.debug.xcconfig */,
+				F274DEF2F4ECD48426EFD4DA /* Pods-GrowingAnalyticsTests.release.xcconfig */,
+				75A09303FD32EECF0AD4EA4D /* Pods-HostApplicationTests.debug.xcconfig */,
+				C6CF7AED52273FB42287E823 /* Pods-HostApplicationTests.release.xcconfig */,
+				667FE81378C014039802CB22 /* Pods-ProtobufTests.debug.xcconfig */,
+				971A522EDA0D265E607070FB /* Pods-ProtobufTests.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -1323,11 +1323,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3494DD242859E07C00A6CE46 /* Build configuration list for PBXNativeTarget "ExampleiOS13" */;
 			buildPhases = (
-				365204E6F7BD275C6F90D4B9 /* [CP] Check Pods Manifest.lock */,
+				7484D1A36D371648A1DF8A08 /* [CP] Check Pods Manifest.lock */,
 				3494DD0A2859E07500A6CE46 /* Sources */,
 				3494DD0B2859E07500A6CE46 /* Frameworks */,
 				3494DD0C2859E07500A6CE46 /* Resources */,
-				A939248FFB4ED8A0394899C9 /* [CP] Embed Pods Frameworks */,
+				ED471B3F18CBA25C7BACF7BB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1360,11 +1360,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 349B528F28C0884400EE88FE /* Build configuration list for PBXNativeTarget "AdvertTests" */;
 			buildPhases = (
-				AE9769AF2F2428D7A0FF1CC2 /* [CP] Check Pods Manifest.lock */,
+				BB75E39D41DEEC0506D7A209 /* [CP] Check Pods Manifest.lock */,
 				349B528728C0884400EE88FE /* Sources */,
 				349B528828C0884400EE88FE /* Frameworks */,
 				349B528928C0884400EE88FE /* Resources */,
-				ED18D3B1A8A8CD6C1C3827FE /* [CP] Embed Pods Frameworks */,
+				4CC7DF088602730AAC13494E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1379,11 +1379,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34AB4E4D279000F5002549FF /* Build configuration list for PBXNativeTarget "GrowingAnalyticsStartTests" */;
 			buildPhases = (
-				2DA96A0C739CA0A36E5BED49 /* [CP] Check Pods Manifest.lock */,
+				673ED9E2EE9361A891AE5FEA /* [CP] Check Pods Manifest.lock */,
 				34AB4E43279000F5002549FF /* Sources */,
 				34AB4E44279000F5002549FF /* Frameworks */,
 				34AB4E45279000F5002549FF /* Resources */,
-				C9359571572AF443D9053519 /* [CP] Embed Pods Frameworks */,
+				6D4E8114EE760AF8D831E925 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1398,11 +1398,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34BA7B1B277C61250030AC21 /* Build configuration list for PBXNativeTarget "GrowingAnalyticsTests" */;
 			buildPhases = (
-				1F464486CC0ECE3D11375B6F /* [CP] Check Pods Manifest.lock */,
+				0016946707C38F6C2184F5CF /* [CP] Check Pods Manifest.lock */,
 				34BA7B13277C61250030AC21 /* Sources */,
 				34BA7B14277C61250030AC21 /* Frameworks */,
 				34BA7B15277C61250030AC21 /* Resources */,
-				6C2C76181A8C318D3015D06E /* [CP] Embed Pods Frameworks */,
+				1CD096A6E460104637EF02A7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1417,11 +1417,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34BA7B33277C63D00030AC21 /* Build configuration list for PBXNativeTarget "ProtobufTests" */;
 			buildPhases = (
-				890E1EF9A8E79B8D3B1FB48A /* [CP] Check Pods Manifest.lock */,
+				44193EBF3E5F2006AAB60F3F /* [CP] Check Pods Manifest.lock */,
 				34BA7B2B277C63D00030AC21 /* Sources */,
 				34BA7B2C277C63D00030AC21 /* Frameworks */,
 				34BA7B2D277C63D00030AC21 /* Resources */,
-				B3CAB2F925F95F95D7B9986C /* [CP] Embed Pods Frameworks */,
+				56C06FFFECBEF94CFB2BD1FF /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1436,11 +1436,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34BF77BE2795561300CA18BA /* Build configuration list for PBXNativeTarget "HostApplicationTests" */;
 			buildPhases = (
-				4B57F54364350CC48631C58B /* [CP] Check Pods Manifest.lock */,
+				50AC72F6C764C8F2696976D2 /* [CP] Check Pods Manifest.lock */,
 				34BF77B42795561300CA18BA /* Sources */,
 				34BF77B52795561300CA18BA /* Frameworks */,
 				34BF77B62795561300CA18BA /* Resources */,
-				C85A6EB11F431DB0CB8B73BE /* [CP] Embed Pods Frameworks */,
+				74721750E8CE0E94EC19DC61 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1456,11 +1456,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34D932FB27BF8A400038430E /* Build configuration list for PBXNativeTarget "GrowingAnalyticsCDPTests" */;
 			buildPhases = (
-				9E9EBD9E72B8C0E80C749542 /* [CP] Check Pods Manifest.lock */,
+				0F665B5D37825C345222D11E /* [CP] Check Pods Manifest.lock */,
 				34D932F327BF8A400038430E /* Sources */,
 				34D932F427BF8A400038430E /* Frameworks */,
 				34D932F527BF8A400038430E /* Resources */,
-				79D0A57D9E1AFE9E2E85ED6F /* [CP] Embed Pods Frameworks */,
+				E06108E447F2A34C1E53DC50 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1682,6 +1682,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0016946707C38F6C2184F5CF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		04A6FAEA24E4F0FB006C72F0 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1716,7 +1738,7 @@
 			shellPath = /bin/sh;
 			shellScript = "##### 代码格式化工具 #####\n# 使用clang-format格式化变动的代码\n# 代码规则见.clang-format\n\ncd ${SRCROOT}/../Scripts\nsh code-format.sh ${SRCROOT}/../\n";
 		};
-		1F464486CC0ECE3D11375B6F /* [CP] Check Pods Manifest.lock */ = {
+		0F665B5D37825C345222D11E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1731,14 +1753,34 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsCDPTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2DA96A0C739CA0A36E5BED49 /* [CP] Check Pods Manifest.lock */ = {
+		1CD096A6E460104637EF02A7 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-c4dd48da/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		44193EBF3E5F2006AAB60F3F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1753,36 +1795,34 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsStartTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-ProtobufTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		365204E6F7BD275C6F90D4B9 /* [CP] Check Pods Manifest.lock */ = {
+		4CC7DF088602730AAC13494E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
+				"${PODS_ROOT}/Target Support Files/Pods-AdvertTests/Pods-AdvertTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b0c2cd62/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
 			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ExampleiOS13-checkManifestLockResult.txt",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AdvertTests/Pods-AdvertTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4B57F54364350CC48631C58B /* [CP] Check Pods Manifest.lock */ = {
+		50AC72F6C764C8F2696976D2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1804,49 +1844,29 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6C2C76181A8C318D3015D06E /* [CP] Embed Pods Frameworks */ = {
+		56C06FFFECBEF94CFB2BD1FF /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-c4dd48da/GrowingAnalytics.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b10f5797/GrowingAnalytics.framework",
 				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		79D0A57D9E1AFE9E2E85ED6F /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-16cd3902/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-cdp/GrowingAnalytics_cdp.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics_cdp.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		890E1EF9A8E79B8D3B1FB48A /* [CP] Check Pods Manifest.lock */ = {
+		673ED9E2EE9361A891AE5FEA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1861,7 +1881,73 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ProtobufTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsStartTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6D4E8114EE760AF8D831E925 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-16cd3902/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-cdp/GrowingAnalytics_cdp.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics_cdp.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		74721750E8CE0E94EC19DC61 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-c99a9474/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+				"${BUILT_PRODUCTS_DIR}/KIF/KIF.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KIF.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7484D1A36D371648A1DF8A08 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ExampleiOS13-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1884,28 +1970,6 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-Example-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9E9EBD9E72B8C0E80C749542 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsCDPTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1944,31 +2008,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A939248FFB4ED8A0394899C9 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAPM/GrowingAPM.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b0c2cd62/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingToolsKit/GrowingToolsKit.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAPM.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingToolsKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AE9769AF2F2428D7A0FF1CC2 /* [CP] Check Pods Manifest.lock */ = {
+		BB75E39D41DEEC0506D7A209 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1990,57 +2030,13 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B3CAB2F925F95F95D7B9986C /* [CP] Embed Pods Frameworks */ = {
+		E06108E447F2A34C1E53DC50 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b10f5797/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C85A6EB11F431DB0CB8B73BE /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-c99a9474/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-				"${BUILT_PRODUCTS_DIR}/KIF/KIF.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KIF.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C9359571572AF443D9053519 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-16cd3902/GrowingAnalytics.framework",
 				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
 				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-cdp/GrowingAnalytics_cdp.framework",
@@ -2053,27 +2049,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		ED18D3B1A8A8CD6C1C3827FE /* [CP] Embed Pods Frameworks */ = {
+		ED471B3F18CBA25C7BACF7BB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AdvertTests/Pods-AdvertTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAPM/GrowingAPM.framework",
 				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b0c2cd62/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingToolsKit/GrowingToolsKit.framework",
 				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAPM.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingToolsKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AdvertTests/Pods-AdvertTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -2442,7 +2442,7 @@
 		};
 		3494DD252859E07C00A6CE46 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2DCB860F6F7A79016D3E103E /* Pods-ExampleiOS13.debug.xcconfig */;
+			baseConfigurationReference = EF77207AC05D4702F8C9C58C /* Pods-ExampleiOS13.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2499,7 +2499,7 @@
 		};
 		3494DD262859E07C00A6CE46 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3F5E5E2D15AE01361CEF96EA /* Pods-ExampleiOS13.release.xcconfig */;
+			baseConfigurationReference = B1A467B42E507DB2C5BF7A46 /* Pods-ExampleiOS13.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2650,7 +2650,7 @@
 		};
 		349B529028C0884400EE88FE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 322A0137D291314D9DA5617A /* Pods-AdvertTests.debug.xcconfig */;
+			baseConfigurationReference = E1FAB1B410063271250FFC6D /* Pods-AdvertTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2696,7 +2696,7 @@
 		};
 		349B529128C0884400EE88FE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3F38C7B6F4B9AA66D1C43C12 /* Pods-AdvertTests.release.xcconfig */;
+			baseConfigurationReference = BE3D8AD215D13B387143219B /* Pods-AdvertTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2743,7 +2743,7 @@
 		};
 		34AB4E4B279000F5002549FF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E381BC17741A543E72DCA2B2 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */;
+			baseConfigurationReference = 60F77CA47D760F5DDE8FFF21 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2789,7 +2789,7 @@
 		};
 		34AB4E4C279000F5002549FF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D01B4845722C332D8F8D39C3 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */;
+			baseConfigurationReference = FBC4514B8EC1B458F43C9820 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2836,7 +2836,7 @@
 		};
 		34BA7B1C277C61250030AC21 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A629672AAF8632F7C9C229BB /* Pods-GrowingAnalyticsTests.debug.xcconfig */;
+			baseConfigurationReference = F286A03FF69374A3647F1EE3 /* Pods-GrowingAnalyticsTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2882,7 +2882,7 @@
 		};
 		34BA7B1D277C61250030AC21 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B53CE07A26B1CF805C783A2F /* Pods-GrowingAnalyticsTests.release.xcconfig */;
+			baseConfigurationReference = F274DEF2F4ECD48426EFD4DA /* Pods-GrowingAnalyticsTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2929,7 +2929,7 @@
 		};
 		34BA7B34277C63D00030AC21 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2B362FDA6F298488AE09B02E /* Pods-ProtobufTests.debug.xcconfig */;
+			baseConfigurationReference = 667FE81378C014039802CB22 /* Pods-ProtobufTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2975,7 +2975,7 @@
 		};
 		34BA7B35277C63D00030AC21 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FD5D59B9A176A76AB87F5674 /* Pods-ProtobufTests.release.xcconfig */;
+			baseConfigurationReference = 971A522EDA0D265E607070FB /* Pods-ProtobufTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3022,7 +3022,7 @@
 		};
 		34BF77BF2795561300CA18BA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 70A32BBD6417C9BF035F83C8 /* Pods-HostApplicationTests.debug.xcconfig */;
+			baseConfigurationReference = 75A09303FD32EECF0AD4EA4D /* Pods-HostApplicationTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -3070,7 +3070,7 @@
 		};
 		34BF77C02795561300CA18BA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0784CB0FF505AC3ED0EC508C /* Pods-HostApplicationTests.release.xcconfig */;
+			baseConfigurationReference = C6CF7AED52273FB42287E823 /* Pods-HostApplicationTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -3119,7 +3119,7 @@
 		};
 		34D932FC27BF8A400038430E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 581FA43E281E2C470D4AAFCD /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */;
+			baseConfigurationReference = B1B0E469D2F9EA36A787D5E7 /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3165,7 +3165,7 @@
 		};
 		34D932FD27BF8A400038430E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C72223C1736A45B1E50A6BD3 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */;
+			baseConfigurationReference = 15B6BB849F26AF0791371D18 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0089C2BFC7A6217241A07E0A /* Pods_HostApplicationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48FE15120F9DB1ACB92044FC /* Pods_HostApplicationTests.framework */; };
 		0465313624DD4272002D254C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 046530D124DD4271002D254C /* Assets.xcassets */; };
 		0465313724DD4272002D254C /* GIODataProcessOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 046530D324DD4271002D254C /* GIODataProcessOperation.m */; };
 		0465313924DD4272002D254C /* GIOConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 046530D724DD4271002D254C /* GIOConstants.m */; };
@@ -75,7 +76,7 @@
 		04A6FAF224E662E9006C72F0 /* GIOChildsAddViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A6FAF124E662E9006C72F0 /* GIOChildsAddViewController.m */; };
 		04A6FAF524E67215006C72F0 /* GIOBaseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A6FAF424E67215006C72F0 /* GIOBaseViewController.m */; };
 		04F675662628293800077374 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04F675652628293800077374 /* AdSupport.framework */; };
-		25E23DDCADDAAB53A5367263 /* Pods_ProtobufTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 266E2480F43F61567BD5452B /* Pods_ProtobufTests.framework */; };
+		2B94D97E1142050DE05C4480 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E4D4EB10715BBF33936F7BC /* Pods_Example.framework */; };
 		34106BB428FECB0E00E7DB01 /* Crasher.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34106BB328FECB0E00E7DB01 /* Crasher.mm */; };
 		34486D3D27B1049000FA8223 /* UITapGestureRecognizerAutotrackTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 34486D3B27B102B000FA8223 /* UITapGestureRecognizerAutotrackTest.m */; };
 		34664587278EEEA6009C351C /* A0GrowingAnalyticsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 047BF3A224F638BB0028FE94 /* A0GrowingAnalyticsTest.m */; };
@@ -162,19 +163,18 @@
 		34C0BF3D277EA9BA0047ADC4 /* MobileDebuggerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 34C0BF3C277EA9BA0047ADC4 /* MobileDebuggerTest.m */; };
 		34D932FE27BF8C640038430E /* MockEventQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 4962653324DA66B600032551 /* MockEventQueue.m */; };
 		34D9330027BF943F0038430E /* A0GrowingAnalyticsCDPTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 34D932F927BF8A400038430E /* A0GrowingAnalyticsCDPTest.m */; };
+		4676881438BA21E27C4F684A /* Pods_GrowingAnalyticsCDPTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20F052195F946572FF10B9DF /* Pods_GrowingAnalyticsCDPTests.framework */; };
 		4916270F24E157BB00444AF2 /* GIOPresentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4916270E24E157BB00444AF2 /* GIOPresentViewController.m */; };
 		4916271224E157CF00444AF2 /* GIOPagingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4916271124E157CF00444AF2 /* GIOPagingViewController.m */; };
 		491D2D8D2500E2D9001CB289 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 491D2D8C2500E2D9001CB289 /* MapKit.framework */; };
-		4F32585B59410FD1D3CF3844 /* Pods_HostApplicationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 487F51C1C74E6664237627A0 /* Pods_HostApplicationTests.framework */; };
+		4BAD0C268E718779953D420E /* Pods_ExampleiOS13.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC2036F16A91796927E923E5 /* Pods_ExampleiOS13.framework */; };
+		51EFDAC79C29C4FF3ED6D77E /* Pods_GrowingAnalyticsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A131AD28D173A2BB6CBF9C8 /* Pods_GrowingAnalyticsTests.framework */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
-		6628095CCF52FD4DEDF13DED /* Pods_GrowingAnalyticsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 10FFC0760C6FFD938CB4268A /* Pods_GrowingAnalyticsTests.framework */; };
-		B4F3B65B1A77008DEE7F9C34 /* Pods_ExampleiOS13.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 819C493DD370F27D12F5D6DC /* Pods_ExampleiOS13.framework */; };
-		D047DAAC904CA728D43F4EB9 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D553B15D3BADC26334C3D7D /* Pods_Example.framework */; };
-		ED1E8596B35A5FB16A05249D /* Pods_AdvertTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32A71E4D81B654C880810E58 /* Pods_AdvertTests.framework */; };
-		F3CC08802A0E3DBA977D45E8 /* Pods_GrowingAnalyticsCDPTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB3CC1051DE1E4A44CAE5DFC /* Pods_GrowingAnalyticsCDPTests.framework */; };
-		FEC707EAB73CE0241EF169EB /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9116ED65D35986BBDA24783E /* Pods_GrowingAnalyticsStartTests.framework */; };
+		9163E777CF42D5727BA71B4F /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1676945A2B2799A168DE8CE /* Pods_GrowingAnalyticsStartTests.framework */; };
+		D30B3E0F1990278E593AADB3 /* Pods_AdvertTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3207E4CA6A3865A7B1C3ACA /* Pods_AdvertTests.framework */; };
+		DC4E9FAD2CDF39E22390DAFA /* Pods_ProtobufTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042ADE8D7A6EB0FAF1C06697 /* Pods_ProtobufTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -202,6 +202,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		042ADE8D7A6EB0FAF1C06697 /* Pods_ProtobufTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProtobufTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		046530BD24DD4271002D254C /* GrowingIO-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GrowingIO-Prefix.pch"; sourceTree = "<group>"; };
 		046530BE24DD4271002D254C /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		046530D124DD4271002D254C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -293,13 +294,13 @@
 		04A6FAF424E67215006C72F0 /* GIOBaseViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GIOBaseViewController.m; sourceTree = "<group>"; };
 		04AEA7E5277319E300ED6CC8 /* GrowingDispatchManagerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GrowingDispatchManagerTest.m; sourceTree = "<group>"; };
 		04F675652628293800077374 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
-		0C2564F9856C51E8D23A8E10 /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsCDPTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests.debug.xcconfig"; sourceTree = "<group>"; };
-		0D553B15D3BADC26334C3D7D /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		10FFC0760C6FFD938CB4268A /* Pods_GrowingAnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		266E2480F43F61567BD5452B /* Pods_ProtobufTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProtobufTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		27783001506F4497CCB4E3BC /* Pods-AdvertTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertTests.release.xcconfig"; path = "Target Support Files/Pods-AdvertTests/Pods-AdvertTests.release.xcconfig"; sourceTree = "<group>"; };
-		3243ADFB0ABE20489F745B71 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsStartTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests.release.xcconfig"; sourceTree = "<group>"; };
-		32A71E4D81B654C880810E58 /* Pods_AdvertTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdvertTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0784CB0FF505AC3ED0EC508C /* Pods-HostApplicationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.release.xcconfig"; sourceTree = "<group>"; };
+		0A131AD28D173A2BB6CBF9C8 /* Pods_GrowingAnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B9B66FA65EE5170181EDDA0 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		20F052195F946572FF10B9DF /* Pods_GrowingAnalyticsCDPTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsCDPTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2B362FDA6F298488AE09B02E /* Pods-ProtobufTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.debug.xcconfig"; path = "Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.debug.xcconfig"; sourceTree = "<group>"; };
+		2DCB860F6F7A79016D3E103E /* Pods-ExampleiOS13.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.debug.xcconfig"; path = "Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.debug.xcconfig"; sourceTree = "<group>"; };
+		322A0137D291314D9DA5617A /* Pods-AdvertTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertTests.debug.xcconfig"; path = "Target Support Files/Pods-AdvertTests/Pods-AdvertTests.debug.xcconfig"; sourceTree = "<group>"; };
 		34106BB228FECB0D00E7DB01 /* Crasher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Crasher.h; sourceTree = "<group>"; };
 		34106BB328FECB0E00E7DB01 /* Crasher.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Crasher.mm; sourceTree = "<group>"; };
 		34486D3B27B102B000FA8223 /* UITapGestureRecognizerAutotrackTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UITapGestureRecognizerAutotrackTest.m; sourceTree = "<group>"; };
@@ -384,8 +385,10 @@
 		34C0BF3C277EA9BA0047ADC4 /* MobileDebuggerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MobileDebuggerTest.m; sourceTree = "<group>"; };
 		34D932F727BF8A400038430E /* GrowingAnalyticsCDPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GrowingAnalyticsCDPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		34D932F927BF8A400038430E /* A0GrowingAnalyticsCDPTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = A0GrowingAnalyticsCDPTest.m; sourceTree = "<group>"; };
+		3F38C7B6F4B9AA66D1C43C12 /* Pods-AdvertTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertTests.release.xcconfig"; path = "Target Support Files/Pods-AdvertTests/Pods-AdvertTests.release.xcconfig"; sourceTree = "<group>"; };
+		3F5E5E2D15AE01361CEF96EA /* Pods-ExampleiOS13.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.release.xcconfig"; path = "Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.release.xcconfig"; sourceTree = "<group>"; };
 		42ADE26B250B292900CA7268 /* HybridTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HybridTest.m; sourceTree = "<group>"; };
-		487F51C1C74E6664237627A0 /* Pods_HostApplicationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApplicationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		48FE15120F9DB1ACB92044FC /* Pods_HostApplicationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApplicationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4916270D24E157BB00444AF2 /* GIOPresentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GIOPresentViewController.h; sourceTree = "<group>"; };
 		4916270E24E157BB00444AF2 /* GIOPresentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GIOPresentViewController.m; sourceTree = "<group>"; };
 		4916271024E157CF00444AF2 /* GIOPagingViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GIOPagingViewController.h; sourceTree = "<group>"; };
@@ -395,27 +398,24 @@
 		4962653224DA66B600032551 /* ManualTrackHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ManualTrackHelper.m; sourceTree = "<group>"; };
 		4962653324DA66B600032551 /* MockEventQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockEventQueue.m; sourceTree = "<group>"; };
 		4962653824DA66B600032551 /* ManualTrackHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ManualTrackHelper.h; sourceTree = "<group>"; };
-		4D4B28DA7BEE83D6D0A4A44B /* Pods-ProtobufTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.debug.xcconfig"; path = "Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.debug.xcconfig"; sourceTree = "<group>"; };
-		5822C520AB25C5E54B34EE73 /* Pods-GrowingAnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		581FA43E281E2C470D4AAFCD /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsCDPTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests.debug.xcconfig"; sourceTree = "<group>"; };
+		5A726A5206E26820EAE1C12C /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		6003F591195388D20070C39A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		6768E68DC014805C0C442D4E /* Pods-ExampleiOS13.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.debug.xcconfig"; path = "Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.debug.xcconfig"; sourceTree = "<group>"; };
-		819C493DD370F27D12F5D6DC /* Pods_ExampleiOS13.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleiOS13.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A6A12BFA13811D067C84CE2 /* Pods-HostApplicationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.debug.xcconfig"; sourceTree = "<group>"; };
-		8EB8A78BA8869C76791234A2 /* Pods-AdvertTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertTests.debug.xcconfig"; path = "Target Support Files/Pods-AdvertTests/Pods-AdvertTests.debug.xcconfig"; sourceTree = "<group>"; };
-		9116ED65D35986BBDA24783E /* Pods_GrowingAnalyticsStartTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsStartTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		960208854ED1279DD5097E3A /* Pods-ProtobufTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.release.xcconfig"; path = "Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.release.xcconfig"; sourceTree = "<group>"; };
-		962F71505986D5D5952555BB /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsCDPTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests.release.xcconfig"; sourceTree = "<group>"; };
-		BB3CC1051DE1E4A44CAE5DFC /* Pods_GrowingAnalyticsCDPTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsCDPTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C5CD014A1F33EEA78FCD67FA /* Pods-ExampleiOS13.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.release.xcconfig"; path = "Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.release.xcconfig"; sourceTree = "<group>"; };
-		D011F7BC6D4178E9CD4887DD /* Pods-GrowingAnalyticsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.release.xcconfig"; sourceTree = "<group>"; };
-		D2F174078967CADA953B2F45 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
-		D3BF27A1F05352E5A9B82BF6 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsStartTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests.debug.xcconfig"; sourceTree = "<group>"; };
-		D3FE389CEEA599E974CF3033 /* Pods-HostApplicationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.release.xcconfig"; sourceTree = "<group>"; };
-		F74EC6BC844287F1EA542152 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		70A32BBD6417C9BF035F83C8 /* Pods-HostApplicationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.debug.xcconfig"; sourceTree = "<group>"; };
+		7E4D4EB10715BBF33936F7BC /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A629672AAF8632F7C9C229BB /* Pods-GrowingAnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		AC2036F16A91796927E923E5 /* Pods_ExampleiOS13.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleiOS13.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3207E4CA6A3865A7B1C3ACA /* Pods_AdvertTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdvertTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B53CE07A26B1CF805C783A2F /* Pods-GrowingAnalyticsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.release.xcconfig"; sourceTree = "<group>"; };
+		C72223C1736A45B1E50A6BD3 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsCDPTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests.release.xcconfig"; sourceTree = "<group>"; };
+		D01B4845722C332D8F8D39C3 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsStartTests.release.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests.release.xcconfig"; sourceTree = "<group>"; };
+		E1676945A2B2799A168DE8CE /* Pods_GrowingAnalyticsStartTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GrowingAnalyticsStartTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E381BC17741A543E72DCA2B2 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsStartTests.debug.xcconfig"; path = "Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FD5D59B9A176A76AB87F5674 /* Pods-ProtobufTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.release.xcconfig"; path = "Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -432,7 +432,7 @@
 			files = (
 				349975FB28BF303100466640 /* iAd.framework in Frameworks */,
 				349975FC28BF303B00466640 /* AdServices.framework in Frameworks */,
-				B4F3B65B1A77008DEE7F9C34 /* Pods_ExampleiOS13.framework in Frameworks */,
+				4BAD0C268E718779953D420E /* Pods_ExampleiOS13.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,7 +447,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED1E8596B35A5FB16A05249D /* Pods_AdvertTests.framework in Frameworks */,
+				D30B3E0F1990278E593AADB3 /* Pods_AdvertTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -455,7 +455,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FEC707EAB73CE0241EF169EB /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */,
+				9163E777CF42D5727BA71B4F /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -463,7 +463,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6628095CCF52FD4DEDF13DED /* Pods_GrowingAnalyticsTests.framework in Frameworks */,
+				51EFDAC79C29C4FF3ED6D77E /* Pods_GrowingAnalyticsTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -471,7 +471,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				25E23DDCADDAAB53A5367263 /* Pods_ProtobufTests.framework in Frameworks */,
+				DC4E9FAD2CDF39E22390DAFA /* Pods_ProtobufTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -479,7 +479,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4F32585B59410FD1D3CF3844 /* Pods_HostApplicationTests.framework in Frameworks */,
+				0089C2BFC7A6217241A07E0A /* Pods_HostApplicationTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -487,7 +487,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F3CC08802A0E3DBA977D45E8 /* Pods_GrowingAnalyticsCDPTests.framework in Frameworks */,
+				4676881438BA21E27C4F684A /* Pods_GrowingAnalyticsCDPTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -502,7 +502,7 @@
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
 				04F675662628293800077374 /* AdSupport.framework in Frameworks */,
 				349975F828BF301000466640 /* AdServices.framework in Frameworks */,
-				D047DAAC904CA728D43F4EB9 /* Pods_Example.framework in Frameworks */,
+				2B94D97E1142050DE05C4480 /* Pods_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1230,7 +1230,7 @@
 				34BA7B18277C61250030AC21 /* GrowingAnalyticsTests */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
-				FB5F533DB11C76869812A84A /* Pods */,
+				6E06FB7C2AABE327D97FC29F /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1262,37 +1262,37 @@
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				32A71E4D81B654C880810E58 /* Pods_AdvertTests.framework */,
-				0D553B15D3BADC26334C3D7D /* Pods_Example.framework */,
-				819C493DD370F27D12F5D6DC /* Pods_ExampleiOS13.framework */,
-				BB3CC1051DE1E4A44CAE5DFC /* Pods_GrowingAnalyticsCDPTests.framework */,
-				9116ED65D35986BBDA24783E /* Pods_GrowingAnalyticsStartTests.framework */,
-				10FFC0760C6FFD938CB4268A /* Pods_GrowingAnalyticsTests.framework */,
-				487F51C1C74E6664237627A0 /* Pods_HostApplicationTests.framework */,
-				266E2480F43F61567BD5452B /* Pods_ProtobufTests.framework */,
+				B3207E4CA6A3865A7B1C3ACA /* Pods_AdvertTests.framework */,
+				7E4D4EB10715BBF33936F7BC /* Pods_Example.framework */,
+				AC2036F16A91796927E923E5 /* Pods_ExampleiOS13.framework */,
+				20F052195F946572FF10B9DF /* Pods_GrowingAnalyticsCDPTests.framework */,
+				E1676945A2B2799A168DE8CE /* Pods_GrowingAnalyticsStartTests.framework */,
+				0A131AD28D173A2BB6CBF9C8 /* Pods_GrowingAnalyticsTests.framework */,
+				48FE15120F9DB1ACB92044FC /* Pods_HostApplicationTests.framework */,
+				042ADE8D7A6EB0FAF1C06697 /* Pods_ProtobufTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		FB5F533DB11C76869812A84A /* Pods */ = {
+		6E06FB7C2AABE327D97FC29F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8EB8A78BA8869C76791234A2 /* Pods-AdvertTests.debug.xcconfig */,
-				27783001506F4497CCB4E3BC /* Pods-AdvertTests.release.xcconfig */,
-				F74EC6BC844287F1EA542152 /* Pods-Example.debug.xcconfig */,
-				D2F174078967CADA953B2F45 /* Pods-Example.release.xcconfig */,
-				6768E68DC014805C0C442D4E /* Pods-ExampleiOS13.debug.xcconfig */,
-				C5CD014A1F33EEA78FCD67FA /* Pods-ExampleiOS13.release.xcconfig */,
-				0C2564F9856C51E8D23A8E10 /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */,
-				962F71505986D5D5952555BB /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */,
-				D3BF27A1F05352E5A9B82BF6 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */,
-				3243ADFB0ABE20489F745B71 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */,
-				5822C520AB25C5E54B34EE73 /* Pods-GrowingAnalyticsTests.debug.xcconfig */,
-				D011F7BC6D4178E9CD4887DD /* Pods-GrowingAnalyticsTests.release.xcconfig */,
-				8A6A12BFA13811D067C84CE2 /* Pods-HostApplicationTests.debug.xcconfig */,
-				D3FE389CEEA599E974CF3033 /* Pods-HostApplicationTests.release.xcconfig */,
-				4D4B28DA7BEE83D6D0A4A44B /* Pods-ProtobufTests.debug.xcconfig */,
-				960208854ED1279DD5097E3A /* Pods-ProtobufTests.release.xcconfig */,
+				322A0137D291314D9DA5617A /* Pods-AdvertTests.debug.xcconfig */,
+				3F38C7B6F4B9AA66D1C43C12 /* Pods-AdvertTests.release.xcconfig */,
+				0B9B66FA65EE5170181EDDA0 /* Pods-Example.debug.xcconfig */,
+				5A726A5206E26820EAE1C12C /* Pods-Example.release.xcconfig */,
+				2DCB860F6F7A79016D3E103E /* Pods-ExampleiOS13.debug.xcconfig */,
+				3F5E5E2D15AE01361CEF96EA /* Pods-ExampleiOS13.release.xcconfig */,
+				581FA43E281E2C470D4AAFCD /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */,
+				C72223C1736A45B1E50A6BD3 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */,
+				E381BC17741A543E72DCA2B2 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */,
+				D01B4845722C332D8F8D39C3 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */,
+				A629672AAF8632F7C9C229BB /* Pods-GrowingAnalyticsTests.debug.xcconfig */,
+				B53CE07A26B1CF805C783A2F /* Pods-GrowingAnalyticsTests.release.xcconfig */,
+				70A32BBD6417C9BF035F83C8 /* Pods-HostApplicationTests.debug.xcconfig */,
+				0784CB0FF505AC3ED0EC508C /* Pods-HostApplicationTests.release.xcconfig */,
+				2B362FDA6F298488AE09B02E /* Pods-ProtobufTests.debug.xcconfig */,
+				FD5D59B9A176A76AB87F5674 /* Pods-ProtobufTests.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -1323,11 +1323,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3494DD242859E07C00A6CE46 /* Build configuration list for PBXNativeTarget "ExampleiOS13" */;
 			buildPhases = (
-				959EA92A6452B4A26214FFBA /* [CP] Check Pods Manifest.lock */,
+				365204E6F7BD275C6F90D4B9 /* [CP] Check Pods Manifest.lock */,
 				3494DD0A2859E07500A6CE46 /* Sources */,
 				3494DD0B2859E07500A6CE46 /* Frameworks */,
 				3494DD0C2859E07500A6CE46 /* Resources */,
-				A79869EA7092C528270C6112 /* [CP] Embed Pods Frameworks */,
+				A939248FFB4ED8A0394899C9 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1360,11 +1360,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 349B528F28C0884400EE88FE /* Build configuration list for PBXNativeTarget "AdvertTests" */;
 			buildPhases = (
-				96F54BF91F1D1A84DDD214EE /* [CP] Check Pods Manifest.lock */,
+				AE9769AF2F2428D7A0FF1CC2 /* [CP] Check Pods Manifest.lock */,
 				349B528728C0884400EE88FE /* Sources */,
 				349B528828C0884400EE88FE /* Frameworks */,
 				349B528928C0884400EE88FE /* Resources */,
-				C22576A013D5BE8BA4EF3B6C /* [CP] Embed Pods Frameworks */,
+				ED18D3B1A8A8CD6C1C3827FE /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1379,11 +1379,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34AB4E4D279000F5002549FF /* Build configuration list for PBXNativeTarget "GrowingAnalyticsStartTests" */;
 			buildPhases = (
-				416860A059B202E628DB5A00 /* [CP] Check Pods Manifest.lock */,
+				2DA96A0C739CA0A36E5BED49 /* [CP] Check Pods Manifest.lock */,
 				34AB4E43279000F5002549FF /* Sources */,
 				34AB4E44279000F5002549FF /* Frameworks */,
 				34AB4E45279000F5002549FF /* Resources */,
-				57FEB61BC8B732C4B3A31B35 /* [CP] Embed Pods Frameworks */,
+				C9359571572AF443D9053519 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1398,11 +1398,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34BA7B1B277C61250030AC21 /* Build configuration list for PBXNativeTarget "GrowingAnalyticsTests" */;
 			buildPhases = (
-				6F8C60F033B7D176B69F244E /* [CP] Check Pods Manifest.lock */,
+				1F464486CC0ECE3D11375B6F /* [CP] Check Pods Manifest.lock */,
 				34BA7B13277C61250030AC21 /* Sources */,
 				34BA7B14277C61250030AC21 /* Frameworks */,
 				34BA7B15277C61250030AC21 /* Resources */,
-				67B5D2EBD27B09E9FA278382 /* [CP] Embed Pods Frameworks */,
+				6C2C76181A8C318D3015D06E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1417,11 +1417,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34BA7B33277C63D00030AC21 /* Build configuration list for PBXNativeTarget "ProtobufTests" */;
 			buildPhases = (
-				E8F581169D3A50F76734681B /* [CP] Check Pods Manifest.lock */,
+				890E1EF9A8E79B8D3B1FB48A /* [CP] Check Pods Manifest.lock */,
 				34BA7B2B277C63D00030AC21 /* Sources */,
 				34BA7B2C277C63D00030AC21 /* Frameworks */,
 				34BA7B2D277C63D00030AC21 /* Resources */,
-				7DC05C5C67B415B0B8304851 /* [CP] Embed Pods Frameworks */,
+				B3CAB2F925F95F95D7B9986C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1436,11 +1436,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34BF77BE2795561300CA18BA /* Build configuration list for PBXNativeTarget "HostApplicationTests" */;
 			buildPhases = (
-				21EA2C58E1D149A5C36FA312 /* [CP] Check Pods Manifest.lock */,
+				4B57F54364350CC48631C58B /* [CP] Check Pods Manifest.lock */,
 				34BF77B42795561300CA18BA /* Sources */,
 				34BF77B52795561300CA18BA /* Frameworks */,
 				34BF77B62795561300CA18BA /* Resources */,
-				B4FF98E522B8AB904A92EE7A /* [CP] Embed Pods Frameworks */,
+				C85A6EB11F431DB0CB8B73BE /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1456,11 +1456,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34D932FB27BF8A400038430E /* Build configuration list for PBXNativeTarget "GrowingAnalyticsCDPTests" */;
 			buildPhases = (
-				E850F60977DB653705CA23AC /* [CP] Check Pods Manifest.lock */,
+				9E9EBD9E72B8C0E80C749542 /* [CP] Check Pods Manifest.lock */,
 				34D932F327BF8A400038430E /* Sources */,
 				34D932F427BF8A400038430E /* Frameworks */,
 				34D932F527BF8A400038430E /* Resources */,
-				C45267BF1F23A7CC6498EFB3 /* [CP] Embed Pods Frameworks */,
+				79D0A57D9E1AFE9E2E85ED6F /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1475,11 +1475,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "Example" */;
 			buildPhases = (
-				83B15752D88F449EC665243F /* [CP] Check Pods Manifest.lock */,
+				8BDFC04D0BB6CE71A284ADBB /* [CP] Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				C94BDD81C27EDFB008BB9116 /* [CP] Embed Pods Frameworks */,
+				A5C594F2AB3697F29EA168B3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1716,93 +1716,7 @@
 			shellPath = /bin/sh;
 			shellScript = "##### 代码格式化工具 #####\n# 使用clang-format格式化变动的代码\n# 代码规则见.clang-format\n\ncd ${SRCROOT}/../Scripts\nsh code-format.sh ${SRCROOT}/../\n";
 		};
-		21EA2C58E1D149A5C36FA312 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-HostApplicationTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		416860A059B202E628DB5A00 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsStartTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		57FEB61BC8B732C4B3A31B35 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-16cd3902/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-cdp/GrowingAnalytics_cdp.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics_cdp.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		67B5D2EBD27B09E9FA278382 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-c4dd48da/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6F8C60F033B7D176B69F244E /* [CP] Check Pods Manifest.lock */ = {
+		1F464486CC0ECE3D11375B6F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1824,29 +1738,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7DC05C5C67B415B0B8304851 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b10f5797/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		83B15752D88F449EC665243F /* [CP] Check Pods Manifest.lock */ = {
+		2DA96A0C739CA0A36E5BED49 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1861,14 +1753,14 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Example-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsStartTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		959EA92A6452B4A26214FFBA /* [CP] Check Pods Manifest.lock */ = {
+		365204E6F7BD275C6F90D4B9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1890,7 +1782,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		96F54BF91F1D1A84DDD214EE /* [CP] Check Pods Manifest.lock */ = {
+		4B57F54364350CC48631C58B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1905,67 +1797,21 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-AdvertTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-HostApplicationTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A79869EA7092C528270C6112 /* [CP] Embed Pods Frameworks */ = {
+		6C2C76181A8C318D3015D06E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAPM/GrowingAPM.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b0c2cd62/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingToolsKit/GrowingToolsKit.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAPM.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingToolsKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B4FF98E522B8AB904A92EE7A /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-c99a9474/GrowingAnalytics.framework",
-				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
-				"${BUILT_PRODUCTS_DIR}/KIF/KIF.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KIF.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C22576A013D5BE8BA4EF3B6C /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AdvertTests/Pods-AdvertTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b0c2cd62/GrowingAnalytics.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-c4dd48da/GrowingAnalytics.framework",
 				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -1975,10 +1821,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AdvertTests/Pods-AdvertTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C45267BF1F23A7CC6498EFB3 /* [CP] Embed Pods Frameworks */ = {
+		79D0A57D9E1AFE9E2E85ED6F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2000,7 +1846,73 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsCDPTests/Pods-GrowingAnalyticsCDPTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C94BDD81C27EDFB008BB9116 /* [CP] Embed Pods Frameworks */ = {
+		890E1EF9A8E79B8D3B1FB48A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ProtobufTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8BDFC04D0BB6CE71A284ADBB /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Example-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9E9EBD9E72B8C0E80C749542 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsCDPTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A5C594F2AB3697F29EA168B3 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2032,7 +1944,31 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E850F60977DB653705CA23AC /* [CP] Check Pods Manifest.lock */ = {
+		A939248FFB4ED8A0394899C9 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAPM/GrowingAPM.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b0c2cd62/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingToolsKit/GrowingToolsKit.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAPM.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingToolsKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AE9769AF2F2428D7A0FF1CC2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2047,33 +1983,97 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-GrowingAnalyticsCDPTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-AdvertTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E8F581169D3A50F76734681B /* [CP] Check Pods Manifest.lock */ = {
+		B3CAB2F925F95F95D7B9986C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
+				"${PODS_ROOT}/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b10f5797/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
 			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ProtobufTests-checkManifestLockResult.txt",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C85A6EB11F431DB0CB8B73BE /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-c99a9474/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+				"${BUILT_PRODUCTS_DIR}/KIF/KIF.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KIF.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C9359571572AF443D9053519 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-16cd3902/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-cdp/GrowingAnalytics_cdp.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics_cdp.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GrowingAnalyticsStartTests/Pods-GrowingAnalyticsStartTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ED18D3B1A8A8CD6C1C3827FE /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AdvertTests/Pods-AdvertTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-b0c2cd62/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils/GrowingUtils.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AdvertTests/Pods-AdvertTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -2442,7 +2442,7 @@
 		};
 		3494DD252859E07C00A6CE46 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6768E68DC014805C0C442D4E /* Pods-ExampleiOS13.debug.xcconfig */;
+			baseConfigurationReference = 2DCB860F6F7A79016D3E103E /* Pods-ExampleiOS13.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2499,7 +2499,7 @@
 		};
 		3494DD262859E07C00A6CE46 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C5CD014A1F33EEA78FCD67FA /* Pods-ExampleiOS13.release.xcconfig */;
+			baseConfigurationReference = 3F5E5E2D15AE01361CEF96EA /* Pods-ExampleiOS13.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2650,7 +2650,7 @@
 		};
 		349B529028C0884400EE88FE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8EB8A78BA8869C76791234A2 /* Pods-AdvertTests.debug.xcconfig */;
+			baseConfigurationReference = 322A0137D291314D9DA5617A /* Pods-AdvertTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2696,7 +2696,7 @@
 		};
 		349B529128C0884400EE88FE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 27783001506F4497CCB4E3BC /* Pods-AdvertTests.release.xcconfig */;
+			baseConfigurationReference = 3F38C7B6F4B9AA66D1C43C12 /* Pods-AdvertTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2743,7 +2743,7 @@
 		};
 		34AB4E4B279000F5002549FF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D3BF27A1F05352E5A9B82BF6 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */;
+			baseConfigurationReference = E381BC17741A543E72DCA2B2 /* Pods-GrowingAnalyticsStartTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2789,7 +2789,7 @@
 		};
 		34AB4E4C279000F5002549FF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3243ADFB0ABE20489F745B71 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */;
+			baseConfigurationReference = D01B4845722C332D8F8D39C3 /* Pods-GrowingAnalyticsStartTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2836,7 +2836,7 @@
 		};
 		34BA7B1C277C61250030AC21 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5822C520AB25C5E54B34EE73 /* Pods-GrowingAnalyticsTests.debug.xcconfig */;
+			baseConfigurationReference = A629672AAF8632F7C9C229BB /* Pods-GrowingAnalyticsTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2882,7 +2882,7 @@
 		};
 		34BA7B1D277C61250030AC21 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D011F7BC6D4178E9CD4887DD /* Pods-GrowingAnalyticsTests.release.xcconfig */;
+			baseConfigurationReference = B53CE07A26B1CF805C783A2F /* Pods-GrowingAnalyticsTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2929,7 +2929,7 @@
 		};
 		34BA7B34277C63D00030AC21 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D4B28DA7BEE83D6D0A4A44B /* Pods-ProtobufTests.debug.xcconfig */;
+			baseConfigurationReference = 2B362FDA6F298488AE09B02E /* Pods-ProtobufTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -2975,7 +2975,7 @@
 		};
 		34BA7B35277C63D00030AC21 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 960208854ED1279DD5097E3A /* Pods-ProtobufTests.release.xcconfig */;
+			baseConfigurationReference = FD5D59B9A176A76AB87F5674 /* Pods-ProtobufTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3022,7 +3022,7 @@
 		};
 		34BF77BF2795561300CA18BA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8A6A12BFA13811D067C84CE2 /* Pods-HostApplicationTests.debug.xcconfig */;
+			baseConfigurationReference = 70A32BBD6417C9BF035F83C8 /* Pods-HostApplicationTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -3070,7 +3070,7 @@
 		};
 		34BF77C02795561300CA18BA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D3FE389CEEA599E974CF3033 /* Pods-HostApplicationTests.release.xcconfig */;
+			baseConfigurationReference = 0784CB0FF505AC3ED0EC508C /* Pods-HostApplicationTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -3119,7 +3119,7 @@
 		};
 		34D932FC27BF8A400038430E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0C2564F9856C51E8D23A8E10 /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */;
+			baseConfigurationReference = 581FA43E281E2C470D4AAFCD /* Pods-GrowingAnalyticsCDPTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3165,7 +3165,7 @@
 		};
 		34D932FD27BF8A400038430E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 962F71505986D5D5952555BB /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */;
+			baseConfigurationReference = C72223C1736A45B1E50A6BD3 /* Pods-GrowingAnalyticsCDPTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3285,7 +3285,7 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F74EC6BC844287F1EA542152 /* Pods-Example.debug.xcconfig */;
+			baseConfigurationReference = 0B9B66FA65EE5170181EDDA0 /* Pods-Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
@@ -3312,7 +3312,7 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D2F174078967CADA953B2F45 /* Pods-Example.release.xcconfig */;
+			baseConfigurationReference = 5A726A5206E26820EAE1C12C /* Pods-Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;

--- a/Example/Example/AppDelegate.m
+++ b/Example/Example/AppDelegate.m
@@ -9,7 +9,7 @@
 #import "AppDelegate.h"
 #import <AppTrackingTransparency/AppTrackingTransparency.h>
 #import <GrowingToolsKit/GrowingToolsKit.h>
-#import <Bugly/Bugly.h>
+//#import <Bugly/Bugly.h>
 
 @interface AppDelegate ()
 
@@ -30,7 +30,7 @@
     [self SDK3rdStart];
 #endif
     
-    [Bugly startWithAppId:@"93004a21ca"];
+//    [Bugly startWithAppId:@"93004a21ca"];
     
     return YES;
 }

--- a/GrowingAnalytics-cdp.podspec
+++ b/GrowingAnalytics-cdp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics-cdp'
-  s.version          = '3.4.7'
+  s.version          = '3.4.8'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics-cdp基于GrowingAnalytics，同样具备自动采集基本的用户行为事件，比如访问和行为数据等。

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.4.7'
+  s.version          = '3.4.8'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -143,6 +143,13 @@ GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和�
     apm.dependency 'GrowingAPM/Core'
   end
 
+  # 使用flutter无埋点插件时，将自动导入该库，正常情况下请勿手动导入
+  s.subspec 'Flutter' do |flutter|
+    flutter.source_files = 'Modules/Flutter/**/*{.h,.m,.c,.cpp,.mm}'
+    flutter.public_header_files = 'Modules/Flutter/Public/*.h'
+    flutter.dependency 'GrowingAnalytics/TrackerCore'
+  end
+
   s.subspec 'DISABLE_IDFA' do |config|
     config.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'GROWING_ANALYSIS_DISABLE_IDFA=1'}
     config.dependency 'GrowingAnalytics/TrackerCore'

--- a/GrowingAutotrackerCore/Impression/GrowingImpressionTrack.m
+++ b/GrowingAutotrackerCore/Impression/GrowingImpressionTrack.m
@@ -242,7 +242,7 @@ static BOOL impTrackIsRegistered = NO;
 - (void)addNode:(UIView *)node inSubView:(BOOL)flag; {
     //如果不可见或者忽略，则不可track
     if ([node growingNodeDonotTrack]) {
-        GIOLogDebug(@"imp track view %@ is donotTrack",node);
+        GIOLogVerbose(@"imp track view %@ is donotTrack", node);
         return;
     }
     if (node.growingIMPTrackEventName.length > 0) {
@@ -264,7 +264,7 @@ static BOOL impTrackIsRegistered = NO;
 - (void)addNode:(UIView *)node {
     //如果不可见或者忽略，则不可track
     if ([node growingNodeDonotTrack]) {
-        GIOLogDebug(@"imp track view %@ is donotTrack",node);
+        GIOLogVerbose(@"imp track view %@ is donotTrack", node);
         return;
     }
     if (node.growingIMPTrackEventName.length > 0) {

--- a/GrowingAutotrackerCore/Page/GrowingPageManager.m
+++ b/GrowingAutotrackerCore/Page/GrowingPageManager.m
@@ -252,7 +252,6 @@
             @"UICompatibilityInputViewController", @"UISystemInputAssistantViewController",
             @"UIPredictionViewController", @"GrowingWindowViewController", @"UIApplicationRotationFollowingController",
             @"UIAlertController",
-            @"FlutterViewController",
         ]];
     }
     return _ignoredPrivateControllers;

--- a/GrowingAutotrackerCore/Page/GrowingPageManager.m
+++ b/GrowingAutotrackerCore/Page/GrowingPageManager.m
@@ -251,7 +251,9 @@
             @"UIInputWindowController", @"UIActivityGroupViewController", @"UIKeyboardHiddenViewController",
             @"UICompatibilityInputViewController", @"UISystemInputAssistantViewController",
             @"UIPredictionViewController", @"GrowingWindowViewController", @"UIApplicationRotationFollowingController",
-            @"UIAlertController",
+            @"UIAlertController", @"_UIAlertControllerTextFieldViewController",
+            @"UICandidateViewController", @"UISystemKeyboardDockController",
+            @"UIKeyboardCameraViewController", @"UIKeyboardCameraRemoteViewController",
         ]];
     }
     return _ignoredPrivateControllers;

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -455,7 +455,7 @@ static GrowingEventManager *sharedInstance = nil;
     for (id <GrowingEventPersistenceProtocol> event in events) {
         [arrayM addObject:event.toJSONObject];
     }
-    GIOLogDebug(@"(channel = %@, events = %@)\n", channel.urlTemplate, arrayM);
+    GIOLogVerbose(@"(channel = %@, events = %@)\n", channel.urlTemplate, arrayM);
 }
 
 #pragma mark - Interceptor

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -40,8 +40,8 @@
 #import "GrowingTrackerCore/Timer/GrowingEventTimer.h"
 #import "GrowingULAppLifecycle.h"
 
-NSString *const GrowingTrackerVersionName = @"3.4.7";
-const int GrowingTrackerVersionCode = 30407;
+NSString *const GrowingTrackerVersionName = @"3.4.8";
+const int GrowingTrackerVersionCode = 30408;
 
 @interface GrowingRealTracker ()
 

--- a/GrowingTrackerCore/Public/GrowingFlutterService.h
+++ b/GrowingTrackerCore/Public/GrowingFlutterService.h
@@ -1,0 +1,30 @@
+//
+//  GrowingFlutterService.h
+//  GrowingAnalytics
+//
+//  Created by YoloMao on 2023/2/28.
+//  Copyright (C) 2022 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import "GrowingBaseService.h"
+
+@protocol GrowingFlutterService <GrowingBaseService>
+
+@required
+
++ (void)onFlutterCircleDataChange:(void(^_Nullable)(NSDictionary *_Nonnull data))handler;
++ (void)onWebCircleStart;
++ (void)onWebCircleStop;
+
+@end

--- a/Modules/Flutter/GrowingFlutterPlugin.h
+++ b/Modules/Flutter/GrowingFlutterPlugin.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) void (^onAppDidBecomeActive)(void);
 @property (nonatomic, copy) void (^onAppDidEnterBackground)(void);
 
-- (void)trackPageEvent:(NSDictionary *)arguments;
+- (void)trackPageEvent:(NSDictionary *)arguments attributes:(NSDictionary <NSString *, NSString *>* _Nullable)attributes;
 - (void)trackViewElementEvent:(NSDictionary *)arguments;
 
 @end

--- a/Modules/Flutter/GrowingFlutterPlugin.h
+++ b/Modules/Flutter/GrowingFlutterPlugin.h
@@ -1,0 +1,40 @@
+//
+// GrowingFlutterPlugin.h
+// GrowingAnalytics
+//
+//  Created by sheng on 2021/8/13.
+//  Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "GrowingModuleProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GrowingFlutterPlugin : NSObject <GrowingModuleProtocol>
+
++ (instancetype)sharedInstance;
+
+@property (nonatomic, copy) void (^onWebCircleStart)(void);
+@property (nonatomic, copy) void (^onWebCircleStop)(void);
+@property (nonatomic, copy) void (^_Nullable onFlutterCircleDataChange)(NSDictionary *data);
+@property (nonatomic, copy) void (^onAppDidBecomeActive)(void);
+@property (nonatomic, copy) void (^onAppDidEnterBackground)(void);
+
+- (void)trackPageEvent:(NSDictionary *)arguments;
+- (void)trackViewElementEvent:(NSDictionary *)arguments;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/Flutter/GrowingFlutterPlugin.m
+++ b/Modules/Flutter/GrowingFlutterPlugin.m
@@ -54,7 +54,7 @@ GrowingMod(GrowingFlutterPlugin)
 
 #pragma mark - Autotrack Event
 
-- (void)trackPageEvent:(NSDictionary *)arguments {
+- (void)trackPageEvent:(NSDictionary *)arguments attributes:(NSDictionary <NSString *, NSString *>* _Nullable)attributes {
     NSString *path = arguments[@"path"];
     if (!path || ![path isKindOfClass:[NSString class]] || path.length == 0) {
         return;
@@ -69,30 +69,8 @@ GrowingMod(GrowingFlutterPlugin)
     if (title && [title isKindOfClass:[NSString class]] && title.length > 0) {
         builder = builder.setTitle(title);
     }
-    NSDictionary *attributes = arguments[@"attributes"];
-    if (attributes && [attributes isKindOfClass:[NSDictionary class]] && attributes.count > 0) {
-        GrowingAttributesBuilder *attrBuilder = GrowingAttributesBuilder.new;
-        for (NSString *key in attributes.allKeys) {
-            id value = attributes[key];
-            if ([value isKindOfClass:[NSString class]]) {
-                [attrBuilder setString:value forKey:key];
-            } else if ([value isKindOfClass:[NSNumber class]]) {
-                [attrBuilder setString:[NSString stringWithFormat:@"%@", value] forKey:key];
-            } else if ([value isKindOfClass:[NSArray class]]) {
-                NSArray *array = (NSArray *)value;
-                NSMutableArray *stringArray = [NSMutableArray array];
-                for (int i = 0; i < array.count; i++) {
-                    id indexValue = array[i];
-                    if ([indexValue isKindOfClass:[NSString class]]) {
-                        [stringArray addObject:indexValue];
-                    } else if ([indexValue isKindOfClass:[NSNumber class]]) {
-                        [stringArray addObject:[NSString stringWithFormat:@"%@", indexValue]];
-                    }
-                }
-                [attrBuilder setArray:stringArray forKey:key];
-            }
-        }
-        builder = builder.setAttributes(attrBuilder.build);
+    if (attributes) {
+        builder = builder.setAttributes(attributes);
     }
     [[GrowingEventManager sharedInstance] postEventBuilder:builder];
 }

--- a/Modules/Flutter/GrowingFlutterPlugin.m
+++ b/Modules/Flutter/GrowingFlutterPlugin.m
@@ -18,6 +18,7 @@
 //  limitations under the License.
 
 #import "Modules/Flutter/GrowingFlutterPlugin.h"
+#import "GrowingTrackerCore/Public/GrowingAttributesBuilder.h"
 #import "GrowingTrackerCore/Event/GrowingEventManager.h"
 #import "GrowingTrackerCore/Event/Autotrack/GrowingPageEvent.h"
 #import "GrowingTrackerCore/Event/Autotrack/GrowingViewElementEvent.h"
@@ -70,7 +71,28 @@ GrowingMod(GrowingFlutterPlugin)
     }
     NSDictionary *attributes = arguments[@"attributes"];
     if (attributes && [attributes isKindOfClass:[NSDictionary class]] && attributes.count > 0) {
-        builder = builder.setAttributes(attributes);
+        GrowingAttributesBuilder *attrBuilder = GrowingAttributesBuilder.new;
+        for (NSString *key in attributes.allKeys) {
+            id value = attributes[key];
+            if ([value isKindOfClass:[NSString class]]) {
+                [attrBuilder setString:value forKey:key];
+            } else if ([value isKindOfClass:[NSNumber class]]) {
+                [attrBuilder setString:[NSString stringWithFormat:@"%@", value] forKey:key];
+            } else if ([value isKindOfClass:[NSArray class]]) {
+                NSArray *array = (NSArray *)value;
+                NSMutableArray *stringArray = [NSMutableArray array];
+                for (int i = 0; i < array.count; i++) {
+                    id indexValue = array[i];
+                    if ([indexValue isKindOfClass:[NSString class]]) {
+                        [stringArray addObject:indexValue];
+                    } else if ([indexValue isKindOfClass:[NSNumber class]]) {
+                        [stringArray addObject:[NSString stringWithFormat:@"%@", indexValue]];
+                    }
+                }
+                [attrBuilder setArray:stringArray forKey:key];
+            }
+        }
+        builder = builder.setAttributes(attrBuilder.build);
     }
     [[GrowingEventManager sharedInstance] postEventBuilder:builder];
 }

--- a/Modules/Flutter/GrowingFlutterPlugin.m
+++ b/Modules/Flutter/GrowingFlutterPlugin.m
@@ -1,0 +1,129 @@
+//
+// GrowingFlutterPlugin.m
+// GrowingAnalytics
+//
+//  Created by sheng on 2021/8/13.
+//  Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import "Modules/Flutter/GrowingFlutterPlugin.h"
+#import "GrowingTrackerCore/Event/GrowingEventManager.h"
+#import "GrowingTrackerCore/Event/Autotrack/GrowingPageEvent.h"
+#import "GrowingTrackerCore/Event/Autotrack/GrowingViewElementEvent.h"
+#import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
+#import "GrowingULAppLifecycle.h"
+
+GrowingMod(GrowingFlutterPlugin)
+
+@interface GrowingFlutterPlugin () <GrowingULAppLifecycleDelegate>
+
+@end
+
+@implementation GrowingFlutterPlugin
+
+#pragma mark - GrowingModuleProtocol
+
+- (void)growingModInit:(GrowingContext *)context {
+    [GrowingULAppLifecycle.sharedInstance addAppLifecycleDelegate:self];
+}
+
++ (BOOL)singleton {
+    return YES;
+}
+
++ (instancetype)sharedInstance {
+    static id plugin = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        plugin = [[GrowingFlutterPlugin alloc] init];
+    });
+    return plugin;
+}
+
+#pragma mark - Autotrack Event
+
+- (void)trackPageEvent:(NSDictionary *)arguments {
+    NSString *path = arguments[@"path"];
+    if (!path || ![path isKindOfClass:[NSString class]] || path.length == 0) {
+        return;
+    }
+    NSNumber *ptm = arguments[@"timestamp"];
+    if (!ptm || ![ptm isKindOfClass:[NSNumber class]]) {
+        return;
+    }
+    
+    GrowingPageBuilder *builder = GrowingPageEvent.builder.setPath(path).setTimestamp(ptm.longLongValue);
+    NSString *title = arguments[@"title"];
+    if (title && [title isKindOfClass:[NSString class]] && title.length > 0) {
+        builder = builder.setTitle(title);
+    }
+    NSDictionary *attributes = arguments[@"attributes"];
+    if (attributes && [attributes isKindOfClass:[NSDictionary class]] && attributes.count > 0) {
+        builder = builder.setAttributes(attributes);
+    }
+    [[GrowingEventManager sharedInstance] postEventBuilder:builder];
+}
+
+- (void)trackViewElementEvent:(NSDictionary *)arguments {
+    NSString *eventType = arguments[@"eventType"];
+    if (!eventType || ![eventType isKindOfClass:[NSString class]] || eventType.length == 0) {
+        return;
+    }
+    NSString *xpath = arguments[@"xpath"];
+    if (!xpath || ![xpath isKindOfClass:[NSString class]] || xpath.length == 0) {
+        return;
+    }
+    NSString *path = arguments[@"path"];
+    if (!path || ![path isKindOfClass:[NSString class]] || path.length == 0) {
+        return;
+    }
+    NSNumber *ptm = arguments[@"pageShowTimestamp"];
+    if (!ptm || ![ptm isKindOfClass:[NSNumber class]]) {
+        return;
+    }
+
+    GrowingViewElementBuilder *builder = GrowingViewElementEvent.builder.setEventType(eventType)
+                                                                        .setXpath(xpath)
+                                                                        .setPath(path)
+                                                                        .setPageShowTimestamp(ptm.longLongValue);
+    NSString *viewContent = arguments[@"textValue"];
+    if (viewContent && [viewContent isKindOfClass:[NSString class]] && viewContent.length > 0) {
+        builder = builder.setTextValue(viewContent);
+    }
+    NSNumber *index = arguments[@"index"];
+    if (index && [index isKindOfClass:[NSNumber class]]) {
+        builder = builder.setIndex(index.intValue);
+    }
+    [[GrowingEventManager sharedInstance] postEventBuilder:builder];
+}
+
+#pragma mark - GrowingULAppLifecycleDelegate
+
+- (void)applicationDidBecomeActive {
+    [GrowingDispatchManager dispatchInGrowingThread:^{
+        if (self.onAppDidBecomeActive) {
+            self.onAppDidBecomeActive();
+        }
+    }];
+}
+
+- (void)applicationDidEnterBackground {
+    [GrowingDispatchManager dispatchInGrowingThread:^{
+        if (self.onAppDidEnterBackground) {
+            self.onAppDidEnterBackground();
+        }
+    }];
+}
+
+@end

--- a/Modules/Flutter/GrowingFlutterWebCircleBridge.h
+++ b/Modules/Flutter/GrowingFlutterWebCircleBridge.h
@@ -1,0 +1,29 @@
+//
+//  GrowingFlutterWebCircleBridge.h
+//  GrowingAnalytics
+//
+//  Created by YoloMao on 2023/2/28.
+//  Copyright (C) 2022 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "GrowingFlutterService.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GrowingFlutterWebCircleBridge : NSObject <GrowingFlutterService>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/Flutter/GrowingFlutterWebCircleBridge.m
+++ b/Modules/Flutter/GrowingFlutterWebCircleBridge.m
@@ -1,0 +1,46 @@
+//
+//  GrowingFlutterWebCircleBridge.m
+//  GrowingAnalytics
+//
+//  Created by YoloMao on 2023/2/28.
+//  Copyright (C) 2022 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import "Modules/Flutter/GrowingFlutterWebCircleBridge.h"
+#import "Modules/Flutter/GrowingFlutterPlugin.h"
+
+GrowingService(GrowingFlutterService, GrowingFlutterWebCircleBridge)
+
+@implementation GrowingFlutterWebCircleBridge
+
++ (void)onFlutterCircleDataChange:(void(^_Nullable)(NSDictionary *_Nonnull data))handler {
+    GrowingFlutterPlugin *plugin = [GrowingFlutterPlugin sharedInstance];
+    plugin.onFlutterCircleDataChange = handler;
+}
+
++ (void)onWebCircleStart {
+    GrowingFlutterPlugin *plugin = [GrowingFlutterPlugin sharedInstance];
+    if (plugin.onWebCircleStart) {
+        plugin.onWebCircleStart();
+    }
+}
+
++ (void)onWebCircleStop {
+    GrowingFlutterPlugin *plugin = [GrowingFlutterPlugin sharedInstance];
+    if (plugin.onWebCircleStop) {
+        plugin.onWebCircleStop();
+    }
+}
+
+@end

--- a/Modules/Flutter/Public/Dummy-GrowingModule-FlutterPlugin.h
+++ b/Modules/Flutter/Public/Dummy-GrowingModule-FlutterPlugin.h
@@ -1,0 +1,21 @@
+//
+//  dummy.h
+//  GrowingAnalytics
+//
+//  Created by YoloMao on 2023/2/20.
+//  Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// There are no actual public headers in the lib. This is a dummy public header to prevent Cocoapods
+// from adding all internal headers as public.

--- a/Modules/WebCircle/GrowingWebCircle.m
+++ b/Modules/WebCircle/GrowingWebCircle.m
@@ -59,8 +59,8 @@
 #import "GrowingTrackerCore/Public/GrowingWebSocketService.h"
 #import "GrowingTrackerCore/GrowingRealTracker.h"
 
-#if __has_include("Modules/Flutter/Public/GrowingFlutterPlugin.h")
-#import "Modules/Flutter/Public/GrowingFlutterPlugin.h"
+#if __has_include("Modules/Flutter/GrowingFlutterPlugin.h")
+#import "Modules/Flutter/GrowingFlutterPlugin.h"
 #define GROWING_ANALYSIS_FLUTTER
 #endif
 

--- a/Podfile
+++ b/Podfile
@@ -15,6 +15,7 @@ target 'Example' do
 #  pod 'GrowingAnalytics/Hybrid', :path => './'
   pod 'GrowingAnalytics/Protobuf', :path => './'
   pod 'GrowingAnalytics/Advert', :path => './'
+#  pod 'GrowingAnalytics/Flutter', :path => './'
 #  pod 'GrowingAnalytics/DISABLE_IDFA', :path => './' #禁用idfa
 
   pod 'GrowingAPM'
@@ -25,7 +26,7 @@ target 'Example' do
   pod 'SDCycleScrollView', '~> 1.75'
   pod 'LBXScan/LBXNative', '2.3'
   pod 'LBXScan/UI', '2.3'
-  pod 'Bugly'
+#  pod 'Bugly'
   pod 'GrowingToolsKit'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,7 +120,7 @@ PODS:
   - LBXScan/Types (2.3)
   - LBXScan/UI (2.3):
     - LBXScan/Types (~> 2.2)
-  - Protobuf (3.21.12)
+  - Protobuf (3.22.0)
   - SDCycleScrollView (1.82):
     - SDWebImage (>= 5.0.0)
   - SDWebImage (5.15.1):
@@ -167,10 +167,10 @@ SPEC CHECKSUMS:
   GrowingUtils: fd6e7d1a87c57dbda30967bbdcbc14546c68cd22
   KIF: 779cdbca106633b94ecee7b036537490ebdbd9de
   LBXScan: e51449f0832d1fe17da632af0d22adeb3cfa3543
-  Protobuf: 120350fc38646e2dedc26f49ecba778184ea1de2
+  Protobuf: 5e6cbc143d02fe08585d86b0098f8b755d2caaab
   SDCycleScrollView: a0d74c3384caa72bdfc81470bdbc8c14b3e1fbcf
   SDWebImage: a254f2c53b46e3fba7946b1f8b8b3eaf00413b92
 
-PODFILE CHECKSUM: e2976c8db8fd164f9cdd14c07e1072ff086b0bc9
+PODFILE CHECKSUM: 64594c82d4ec64f37133d304431a7602ce7f793b
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-  - Bugly (2.5.93)
   - GrowingAnalytics-cdp/Autotracker (3.4.7):
     - GrowingAnalytics-cdp/TrackerCore (= 3.4.7)
     - GrowingAnalytics/AutotrackerCore (= 3.4.7)
@@ -129,7 +128,6 @@ PODS:
   - SDWebImage/Core (5.15.1)
 
 DEPENDENCIES:
-  - Bugly
   - GrowingAnalytics-cdp/Autotracker (from `./`)
   - GrowingAnalytics-cdp/Tracker (from `./`)
   - GrowingAnalytics/Advert (from `./`)
@@ -146,7 +144,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - Bugly
     - GrowingAPM
     - GrowingToolsKit
     - GrowingUtils
@@ -163,7 +160,6 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  Bugly: b8715e6ec4004b7f7fbffab0643ba80545aee3da
   GrowingAnalytics: 920b35f73590c7161e1d54d6f9b6c0d0e3f4a022
   GrowingAnalytics-cdp: a8b2fbb1e47485813cabe6fe1dc3fe097bb8cff1
   GrowingAPM: ce25d89b064df78eabfefe807fdecabe92602186
@@ -175,6 +171,6 @@ SPEC CHECKSUMS:
   SDCycleScrollView: a0d74c3384caa72bdfc81470bdbc8c14b3e1fbcf
   SDWebImage: a254f2c53b46e3fba7946b1f8b8b3eaf00413b92
 
-PODFILE CHECKSUM: 7cd8c883be5ccb32d2328e63e1f1595323240cb1
+PODFILE CHECKSUM: e2976c8db8fd164f9cdd14c07e1072ff086b0bc9
 
 COCOAPODS: 1.11.3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GrowingIO Autotracker
 
 ## License
 ```
-Copyright (C) 2022 Beijing Yishu Technology Co., Ltd.
+Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ ignore:
   - "Example"
   - "GrowingTrackerCore/Thirdparty"
   - "Modules/Protobuf/Proto/*.pbobjc.m"
+  - "Modules/Flutter"
   - "Services/Compression/LZ4"
   - "Services/Database/FMDB"
   - "Services/WebSocket"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,7 @@ sonar.sources = .
 sonar.exclusions = Example/**,\
 				   GrowingTrackerCore/Thirdparty/**,\
 				   Modules/Protobuf/Proto/*.pbobjc.m,\
+				   Modules/Flutter/**,\
 				   Services/Compression/LZ4/**,\
 				   Services/Database/FMDB/**,\
 				   Services/WebSocket/**, \


### PR DESCRIPTION
## PR 内容 (Outdated, 见下方 PR 内容)

~~A. 适配flutter无埋点功能，添加flutterplugin类，用于原生和flutter之间相互传值，同时flutter的无埋点插件[flutter-growingio-sdk-autotracker-plugin](https://github.com/growingio/flutter-growingio-sdk-autotracker-plugin)会依赖这里的flutter模块，使得默认情况下无flutter埋点相关代码，但如果集成了flutter的无埋点插件[flutter-growingio-sdk-autotracker-plugin](https://github.com/growingio/flutter-growingio-sdk-autotracker-plugin)，则会加入flutter相关的代码功能~~
~~B. fix了圈选部分，在不杀死app情况下，再次圈选时无响应的问题bug~~

## 测试步骤

~~1. 正常sdk使用圈选时，无flutter模块，且功能正常~~
~~2. 使用 [flutter-growingio-sdk-autotracker-plugin](https://github.com/growingio/flutter-growingio-sdk-autotracker-plugin) 时，会自动导入flutter模块~~
~~3. 两种情况下圈选功能都应正常~~
~~4. 圈选退出后，不杀死app，再扫码圈选，此时应该能够继续圈选~~

## 影响范围

~~仅有概率会影响圈选逻辑~~

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

无

