### PR TITLE
feat: Configuration 增加 EncryptEnabled 配置项

### DIFF
--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.3.1'
+  s.version          = '3.3.1-hotfix.1'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。
@@ -107,6 +107,7 @@ GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和�
       config.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'GROWING_ANALYSIS_DISABLE_IDFA=1'}
   end
 
+  # deprecated
   s.subspec 'ENABLE_ENCRYPTION' do |config|
       config.dependency 'GrowingAnalytics/TrackerCore'
       config.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'GROWING_ANALYSIS_ENABLE_ENCRYPTION=1'}

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -37,7 +37,7 @@
 #import "GrowingModuleManager.h"
 #import "GrowingEventManager.h"
 
-NSString *const GrowingTrackerVersionName = @"3.3.1";
+NSString *const GrowingTrackerVersionName = @"3.3.1-hotfix.1";
 const int GrowingTrackerVersionCode = 30301;
 
 @interface GrowingRealTracker ()
@@ -103,6 +103,16 @@ const int GrowingTrackerVersionCode = 30301;
 - (void)versionPrint {
     NSString *versionStr = [NSString stringWithFormat:@"Thank you very much for using GrowingIO. We will do our best to provide you with the best service. GrowingIO version: %@",GrowingTrackerVersionName];
     GIOLogInfo(@"%@", versionStr);
+    
+#ifdef GROWING_ANALYSIS_ENABLE_ENCRYPTION
+    GIOLogWarn(@"\n"
+               @"╔═══════════════════════════════════════════════════════════════════════════════════════\n"
+               @"║ \n"
+               @"║ WARNING: pod ENABLE_ENCRYPTION is deprecated, please use -[GrowingTrackConfiguration setEncryptEnabled]\n"
+               @"║ 警告: pod ENABLE_ENCRYPTION 已被废弃, 请使用 -[GrowingTrackConfiguration setEncryptEnabled] 进行配置\n"
+               @"║ \n"
+               @"╚═══════════════════════════════════════════════════════════════════════════════════════");
+#endif
 }
 
 + (NSString *)versionName {

--- a/GrowingTrackerCore/GrowingTrackConfiguration.h
+++ b/GrowingTrackerCore/GrowingTrackConfiguration.h
@@ -37,6 +37,7 @@ FOUNDATION_EXPORT NSString * const kGrowingDefaultDataCollectionServerHost;
 @property (nonatomic, assign) NSUInteger ignoreField;
 @property (nonatomic, assign) BOOL idMappingEnabled;
 @property (nonatomic, copy) NSString *urlScheme;
+@property (nonatomic, assign) BOOL encryptEnabled;
 
 - (instancetype)initWithProjectId:(NSString *)projectId;
 

--- a/GrowingTrackerCore/GrowingTrackConfiguration.m
+++ b/GrowingTrackerCore/GrowingTrackConfiguration.m
@@ -40,6 +40,7 @@ NSString * const kGrowingDefaultDataCollectionServerHost = @"https://api.growing
         _ignoreField = 0;
         _idMappingEnabled = NO;
         _urlScheme = nil;
+        _encryptEnabled = NO;
     }
 
     return self;
@@ -63,6 +64,7 @@ NSString * const kGrowingDefaultDataCollectionServerHost = @"https://api.growing
     configuration->_ignoreField = _ignoreField;
     configuration->_idMappingEnabled = _idMappingEnabled;
     configuration->_urlScheme = _urlScheme;
+    configuration->_encryptEnabled = _encryptEnabled;
     return configuration;
 }
 


### PR DESCRIPTION
## PR 内容

- Configuration 增加 EncryptEnabled 配置项，默认值为 NO，不开启加密
- 通过日志提示原有的 subspec `ENABLE_ENCRYPTION`已废弃
- 版本号改为`3.3.1-hotfix.1`

## 测试步骤

- 集成`pod 'GrowingAnalytics/ENABLE_ENCRYPTION'`，并`setEncryptEnabled = YES`，加密为开启状态
- 集成`pod 'GrowingAnalytics/ENABLE_ENCRYPTION'`，并`setEncryptEnabled = NO`，加密为开启状态（旧版本兼容）
- 不集成`pod 'GrowingAnalytics/ENABLE_ENCRYPTION'`，并`setEncryptEnabled = YES`，加密为开启状态
- 不集成`pod 'GrowingAnalytics/ENABLE_ENCRYPTION'`，并`setEncryptEnabled = NO`，加密为关闭状态

## 影响范围

- 集成文档需要更新 EncryptEnabled 配置项，并去除`pod 'GrowingAnalytics/ENABLE_ENCRYPTION'`的方式
- 兼容 SDK 旧版本

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

无

