### PR TITLE
fix: dyld不调用NSClassFromString

### DIFF
--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.3.1-hotfix.1'
+  s.version          = '3.3.1-hotfix.2'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/GrowingTrackerCore/Core/GrowingModuleManager.h
+++ b/GrowingTrackerCore/Core/GrowingModuleManager.h
@@ -62,14 +62,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
+#pragma mark - dyld期间添加module信息
+
+- (void)addLocalModule:(NSString *)modulename;
+
+#pragma mark - 调用方法
 // If you do not comply with set Level protocol, the default Normal
+// 将 class 存入Module Info，并不会初始化
 - (void)registerDynamicModule:(Class)moduleClass;
 
 - (void)unRegisterDynamicModule:(Class)moduleClass;
 
-//- (void)loadLocalModules;
-
+// 初始化各个Module Info
 - (void)registedAllModules;
+
+#pragma mark - 事件和module关联
 
 - (void)registerCustomEvent:(NSInteger)eventType
          withModuleInstance:(id)moduleInstance

--- a/GrowingTrackerCore/Core/GrowingServiceManager.h
+++ b/GrowingTrackerCore/Core/GrowingServiceManager.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
+- (void)registerServiceName:(NSString *)serviceName implClassName:(NSString *)serviceClassName;
+
 - (void)registerService:(Protocol*)service implClass:(Class)serviceClass;
 
 - (id)createService:(Protocol*)service;

--- a/GrowingTrackerCore/Core/GrowingServiceManager.m
+++ b/GrowingTrackerCore/Core/GrowingServiceManager.m
@@ -47,6 +47,12 @@ static GrowingServiceManager *manager = nil;
 
 #pragma mark - private
 
+- (void)registerServiceName:(NSString *)serviceName implClassName:(NSString *)serviceClassName {
+    dispatch_semaphore_wait(_signallock, DISPATCH_TIME_FOREVER);
+    [_allServiceDict setValue:serviceClassName forKey:serviceName];
+    dispatch_semaphore_signal(_signallock);
+}
+
 - (void)registerService:(Protocol*)service implClass:(Class)serviceClass {
     dispatch_semaphore_wait(_signallock, DISPATCH_TIME_FOREVER);
     [_allServiceDict setValue:NSStringFromClass(serviceClass) forKey:NSStringFromProtocol(service)];

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -37,7 +37,7 @@
 #import "GrowingModuleManager.h"
 #import "GrowingEventManager.h"
 
-NSString *const GrowingTrackerVersionName = @"3.3.1-hotfix.1";
+NSString *const GrowingTrackerVersionName = @"3.3.1-hotfix.2";
 const int GrowingTrackerVersionCode = 30301;
 
 @interface GrowingRealTracker ()


### PR DESCRIPTION
## PR 内容

<!-- 在下方描述你的PR实现了什么功能，或者修复了什么问题 -->

修改dyld回调中，只存入string字符串，减少dyld回调期间操作，将moduleInfo生成放入sdk初始化中

## 测试步骤

<!-- 请描述怎样操作才证明已经处理了问题. -->

模块以及service功能响应应正常，不受影响

## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->

无

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

Close #168 , 并不是修复 #168 的问题，只是与其相关

