### PR TITLE
fix: 对dyld部分操作使用纯c实现，避开runtime冲突

### DIFF
--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.3.1-hotfix.2'
+  s.version          = '3.3.1-hotfix.3'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/GrowingTrackerCore/Core/GrowingAnnotationCore.h
+++ b/GrowingTrackerCore/Core/GrowingAnnotationCore.h
@@ -19,8 +19,8 @@
 
 
 #import <Foundation/Foundation.h>
-#import "GrowingServiceManager.h"
 #import "GrowingModuleManager.h"
+#import "GrowingServiceManager.h"
 
 #ifndef GrowingModSectName
 
@@ -43,11 +43,15 @@ class GrowingAnnotationCore; char * k##name##_mod GrowingDATA(GrowingMods) = ""#
 
 #define GrowingDATA(sectname) __attribute((used, section("__DATA,"#sectname"")))
 
+//最大支持 module service 数量限制
+#define growing_section_size 128
 
-NS_ASSUME_NONNULL_BEGIN
+struct _growing_section {
+    uintptr_t charAddress[growing_section_size];
+    uint count;
+};
 
-@interface GrowingAnnotationCore : NSObject
+typedef struct _growing_section growing_section;
 
-@end
-
-NS_ASSUME_NONNULL_END
+extern growing_section growingSectionDataModule(void);
+extern growing_section growingSectionDataService(void);

--- a/GrowingTrackerCore/Core/GrowingAnnotationCore.h
+++ b/GrowingTrackerCore/Core/GrowingAnnotationCore.h
@@ -35,16 +35,16 @@
 #endif
 
 #define GrowingService(servicename,impl) \
-class GrowingAnnotationCore; char * k##servicename##_service GrowingDATA(GrowingServices) = "{ \""#servicename"\" : \""#impl"\"}";
+char * k##servicename##_service GrowingDATA(GrowingServices) = "{ \""#servicename"\" : \""#impl"\"}";
 
 
 #define GrowingMod(name) \
-class GrowingAnnotationCore; char * k##name##_mod GrowingDATA(GrowingMods) = ""#name"";
+char * k##name##_mod GrowingDATA(GrowingMods) = ""#name"";
 
 #define GrowingDATA(sectname) __attribute((used, section("__DATA,"#sectname"")))
 
-//最大支持 module service 数量限制
-#define growing_section_size 128
+//最大支持 module/service 数量限制
+#define growing_section_size 64
 
 struct _growing_section {
     uintptr_t charAddress[growing_section_size];

--- a/GrowingTrackerCore/Core/GrowingModuleManager.h
+++ b/GrowingTrackerCore/Core/GrowingModuleManager.h
@@ -62,10 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
-#pragma mark - dyld期间添加module信息
-
-- (void)addLocalModule:(NSString *)modulename;
-
 #pragma mark - 调用方法
 // If you do not comply with set Level protocol, the default Normal
 // 将 class 存入Module Info，并不会初始化

--- a/GrowingTrackerCore/Core/GrowingModuleManager.m
+++ b/GrowingTrackerCore/Core/GrowingModuleManager.m
@@ -85,10 +85,6 @@ static  NSString *kAppCustomSelector = @"growingModDidCustomEvent:";
     });
     return sharedManager;
 }
-// 仅添加string，规避运行时转换class
-- (void)addLocalModule:(NSString *)modulename {
-    [self.growingModuleNames addObject:modulename];
-}
 
 // 从存储的name数组中读取所有的module
 - (void)loadLocalModules {

--- a/GrowingTrackerCore/Core/GrowingModuleManager.m
+++ b/GrowingTrackerCore/Core/GrowingModuleManager.m
@@ -21,6 +21,8 @@
 #import "GrowingModuleManager.h"
 #import "GrowingModuleProtocol.h"
 #import "GrowingContext.h"
+#import "GrowingAnnotationCore.h"
+#import "GrowingLogger.h"
 #import <objc/runtime.h>
 #import <objc/message.h>
 
@@ -90,6 +92,16 @@ static  NSString *kAppCustomSelector = @"growingModDidCustomEvent:";
 
 // 从存储的name数组中读取所有的module
 - (void)loadLocalModules {
+    // add form section data
+    growing_section section = growingSectionDataModule();
+    for (int i = 0; i < section.count; i++) {
+        char *string = (char *)section.charAddress[i];
+        NSString *str = [NSString stringWithUTF8String:string];
+        if (!str) continue;
+        GIOLogDebug(@"[GrowingModuleManager] load %@",str);
+        if (str) [self.growingModuleNames addObject:str];
+    }
+    
     for (NSString *name in self.growingModuleNames) {
         [self registerDynamicModule:NSClassFromString(name)];
     }

--- a/GrowingTrackerCore/Core/GrowingServiceManager.h
+++ b/GrowingTrackerCore/Core/GrowingServiceManager.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
+- (void)loadLocalServices;
+
 - (void)registerServiceName:(NSString *)serviceName implClassName:(NSString *)serviceClassName;
 
 - (void)registerService:(Protocol*)service implClass:(Class)serviceClass;

--- a/GrowingTrackerCore/Core/GrowingServiceManager.m
+++ b/GrowingTrackerCore/Core/GrowingServiceManager.m
@@ -82,7 +82,7 @@ static GrowingServiceManager *manager = nil;
                 NSString *protocol = [json allKeys][0];
                 NSString *clsName = [json allValues][0];
                 if (protocol && clsName) {
-                    GIOLogDebug(@"[GrowingServiceManager] load protocl %@ clsname %@",protocol,clsName);
+                    GIOLogDebug(@"[GrowingServiceManager] load protocol %@ clsname %@",protocol,clsName);
                     [[GrowingServiceManager sharedInstance] registerServiceName:protocol implClassName:clsName];
                 }
             }

--- a/GrowingTrackerCore/Core/Services/GrowingEventDatabaseService.h
+++ b/GrowingTrackerCore/Core/Services/GrowingEventDatabaseService.h
@@ -56,7 +56,7 @@ extern NSString *const GrowingEventDatabaseErrorDomain;
 
 /// 获取事件
 /// @param count 数量
-/// @param sendPolicys 允许的发送协议（数组）
+/// @param mask 允许的发送协议（数组）
 /// @return 事件对象数组，可为空；若返回值为nil，表示读取错误
 - (NSArray<GrowingEventPersistence *> *)getEventsByCount:(NSUInteger)count policy:(NSUInteger)mask;
 

--- a/GrowingTrackerCore/DataBase/GrowingEventDatabase.m
+++ b/GrowingTrackerCore/DataBase/GrowingEventDatabase.m
@@ -21,6 +21,7 @@
 #import <pthread.h>
 #import "GrowingLogger.h"
 #import "GrowingEventDatabaseService.h"
+#import "GrowingServiceManager.h"
 
 long long const GrowingEventDatabaseExpirationTime = 86400000 * 7;
 NSString *const GrowingEventDatabaseErrorDomain = @"com.growing.event.database.error";

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -35,6 +35,7 @@
 #import "GrowingAppDelegateAutotracker.h"
 #import "GrowingDeepLinkHandler.h"
 #import "GrowingModuleManager.h"
+#import "GrowingServiceManager.h"
 #import "GrowingEventManager.h"
 
 NSString *const GrowingTrackerVersionName = @"3.3.1-hotfix.2";
@@ -64,6 +65,7 @@ const int GrowingTrackerVersionCode = 30301;
         [GrowingSession startSession];
         [GrowingAppDelegateAutotracker track];
         [[GrowingModuleManager sharedInstance] registedAllModules];
+        [[GrowingServiceManager sharedInstance] loadLocalServices];
         [[GrowingModuleManager sharedInstance] triggerEvent:GrowingMInitEvent];
         // 各个Module初始化init之后再进行事件定时发送
         [[GrowingEventManager sharedInstance] configChannels];

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -38,7 +38,7 @@
 #import "GrowingServiceManager.h"
 #import "GrowingEventManager.h"
 
-NSString *const GrowingTrackerVersionName = @"3.3.1-hotfix.2";
+NSString *const GrowingTrackerVersionName = @"3.3.1-hotfix.3";
 const int GrowingTrackerVersionCode = 30301;
 
 @interface GrowingRealTracker ()

--- a/Modules/Hybrid/GrowingHybridModule.m
+++ b/Modules/Hybrid/GrowingHybridModule.m
@@ -23,7 +23,7 @@
 #import "WKWebView+GrowingAutotracker.h"
 #import "GrowingLogger.h"
 
-@GrowingMod(GrowingHybridModule)
+GrowingMod(GrowingHybridModule)
 
 @implementation GrowingHybridModule
 

--- a/Modules/MobileDebugger/GrowingMobileDebugger.m
+++ b/Modules/MobileDebugger/GrowingMobileDebugger.m
@@ -53,7 +53,7 @@
 __VA_ARGS__; \
 dispatch_semaphore_signal(self->_lock);
 
-@GrowingMod(GrowingMobileDebugger)
+GrowingMod(GrowingMobileDebugger)
 
 @interface GrowingMobileDebugger () <GrowingWebSocketDelegate,
                                 GrowingApplicationEventProtocol,

--- a/Modules/WebCircle/GrowingWebCircle.m
+++ b/Modules/WebCircle/GrowingWebCircle.m
@@ -61,7 +61,7 @@
 #import "GrowingWebSocketService.h"
 #import "GrowingRealTracker.h"
 
-@GrowingMod(GrowingWebCircle)
+GrowingMod(GrowingWebCircle)
 
 @interface GrowingWeakObject : NSObject
 @property (nonatomic, weak) JSContext *context;

--- a/Services/Compression/GrowingDataCompression.m
+++ b/Services/Compression/GrowingDataCompression.m
@@ -21,7 +21,7 @@
 #import "GrowingDataCompression.h"
 #import "GrowingLZ4.h"
 
-@GrowingService(GrowingCompressService, GrowingDataCompression)
+GrowingService(GrowingCompressService, GrowingDataCompression)
 
 @implementation GrowingDataCompression
 

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -24,7 +24,7 @@
 #import "GrowingEventPersistence.h"
 #import "GrowingTimeUtil.h"
 
-@GrowingService(GrowingEventDatabaseService, GrowingEventFMDatabase)
+GrowingService(GrowingEventDatabaseService, GrowingEventFMDatabase)
 
 #define VACUUM_DATE(name) [NSString stringWithFormat:@"GIO_VACUUM_DATE_E7B96C4E-6EE2-49CD-87F0-B2E62D4EE96A-%@", name]
 

--- a/Services/Encryption/GrowingDataEncoder.m
+++ b/Services/Encryption/GrowingDataEncoder.m
@@ -20,7 +20,7 @@
 
 #import "GrowingDataEncoder.h"
 
-@GrowingService(GrowingEncryptionService, GrowingDataEncoder)
+GrowingService(GrowingEncryptionService, GrowingDataEncoder)
 
 @implementation GrowingDataEncoder
 

--- a/Services/Network/GrowingNetworkManager.m
+++ b/Services/Network/GrowingNetworkManager.m
@@ -23,7 +23,7 @@
 #import "GrowingAnnotationCore.h"
 #import "GrowingLogger.h"
 
-@GrowingService(GrowingEventNetworkService, GrowingNetworkManager)
+GrowingService(GrowingEventNetworkService, GrowingNetworkManager)
 
 @interface GrowingNetworkManager ()
 

--- a/Services/WebSocket/GrowingSRWebSocket.m
+++ b/Services/WebSocket/GrowingSRWebSocket.m
@@ -49,7 +49,7 @@
 
 #import "GrowingSRWebSocket.h"
 
-@GrowingService(GrowingWebSocketService, GrowingSRWebSocket)
+GrowingService(GrowingWebSocketService, GrowingSRWebSocket)
 
 #if TARGET_OS_IPHONE
 #define HAS_ICU


### PR DESCRIPTION
## PR 内容

<!-- 在下方描述你的PR实现了什么功能，或者修复了什么问题 -->

对 dyld callback中的操作，使用纯c处理，防止与百度sdk冲突，该冲突问题是：百度sdk在异步持有runtime lock时，又请求dyld lock，而我们sdk，主线程中持有dyld lock时，由于使用 NSString 等oc类，会请求runtime lock，导致死锁。


## 测试步骤

<!-- 请描述怎样操作才证明已经处理了问题. -->

pod 'BaiduMapKit','6.3.1' 与百度sdk兼容测试通过，问题为偶现

## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->

影响 module 和 service 的加载

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

无

