### PR TITLE
fix: 替换 Demo 中的 UIAlertView API 调用，改用 UIAlertController

### DIFF
--- a/Example/Example/UICategoryTests/GIOButtonViewController.m
+++ b/Example/Example/UICategoryTests/GIOButtonViewController.m
@@ -16,7 +16,7 @@ typedef NS_ENUM(NSInteger, AAPLAlertsViewControllerTableRow) {
     AAPLAlertsViewControllerActionSheetRowTextEntrySecure
 };
 
-@interface GIOButtonViewController ()<UIAlertViewDelegate>
+@interface GIOButtonViewController ()<UITextFieldDelegate>
 
 @property (nonatomic, weak) IBOutlet UIButton *systemTextButton;
 @property (nonatomic, weak) IBOutlet UIButton *systemContactAddButton;
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSInteger, AAPLAlertsViewControllerTableRow) {
 @property (nonatomic, weak) IBOutlet UIButton *imageButton;
 @property (nonatomic, weak) IBOutlet UIButton *attributedTextButton;
 @property (weak, nonatomic) IBOutlet UIButton *imageAndTextButton;
+@property (nonatomic, strong) UIAlertAction *otherAction;
 
 @end
 
@@ -66,9 +67,12 @@ typedef NS_ENUM(NSInteger, AAPLAlertsViewControllerTableRow) {
     NSString *message = NSLocalizedString(@"A message should be a short, complete sentence.", nil);
     NSString *cancelButtonTitle = NSLocalizedString(@"OK", nil);
     
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:nil];
-    
-    [alert show];   
+    UIAlertController *controller = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    __weak typeof(self) weakSelf = self;
+    [controller addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    [self presentViewController:controller animated:YES completion:nil];
 }
 
 // Show an alert with an "Okay" and "Cancel" button.
@@ -78,9 +82,15 @@ typedef NS_ENUM(NSInteger, AAPLAlertsViewControllerTableRow) {
     NSString *cancelButtonTitle = NSLocalizedString(@"Cancel", nil);
     NSString *otherButtonTitle = NSLocalizedString(@"OK", nil);
     
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:otherButtonTitle, nil];
-    
-    [alert show];
+    UIAlertController *controller = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    __weak typeof(self) weakSelf = self;
+    [controller addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    [controller addAction:[UIAlertAction actionWithTitle:otherButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    [self presentViewController:controller animated:YES completion:nil];
 }
 
 // Show an alert with two custom buttons.
@@ -91,9 +101,18 @@ typedef NS_ENUM(NSInteger, AAPLAlertsViewControllerTableRow) {
     NSString *otherButtonTitleOne = NSLocalizedString(@"Choice One", nil);
     NSString *otherButtonTitleTwo = NSLocalizedString(@"Choice Two", nil);
     
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:otherButtonTitleOne, otherButtonTitleTwo, nil];
-    
-    [alert show];
+    UIAlertController *controller = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    __weak typeof(self) weakSelf = self;
+    [controller addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    [controller addAction:[UIAlertAction actionWithTitle:otherButtonTitleOne style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    [controller addAction:[UIAlertAction actionWithTitle:otherButtonTitleTwo style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    [self presentViewController:controller animated:YES completion:nil];
 }
 
 // Show a text entry alert with two custom buttons.
@@ -103,11 +122,16 @@ typedef NS_ENUM(NSInteger, AAPLAlertsViewControllerTableRow) {
     NSString *cancelButtonTitle = NSLocalizedString(@"Cancel", nil);
     NSString *otherButtonTitle = NSLocalizedString(@"OK", nil);
     
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:otherButtonTitle, nil];
-    
-    alert.alertViewStyle = UIAlertViewStylePlainTextInput;
-    
-    [alert show];
+    UIAlertController *controller = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    __weak typeof(self) weakSelf = self;
+    [controller addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    [controller addAction:[UIAlertAction actionWithTitle:otherButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    [controller addTextFieldWithConfigurationHandler:nil];
+    [self presentViewController:controller animated:YES completion:nil];
 }
 
 // Show a secure text entry alert with two custom buttons.
@@ -117,11 +141,21 @@ typedef NS_ENUM(NSInteger, AAPLAlertsViewControllerTableRow) {
     NSString *cancelButtonTitle = NSLocalizedString(@"Cancel", nil);
     NSString *otherButtonTitle = NSLocalizedString(@"OK", nil);
     
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:otherButtonTitle, nil];
-    
-    alert.alertViewStyle = UIAlertViewStyleSecureTextInput;
-    
-    [alert show];
+    UIAlertController *controller = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    __weak typeof(self) weakSelf = self;
+    [controller addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }]];
+    self.otherAction = [UIAlertAction actionWithTitle:otherButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [weakSelf actionClicked:action];
+    }];
+    self.otherAction.enabled = NO;
+    [controller addAction:self.otherAction];
+    [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        textField.secureTextEntry = YES;
+        textField.delegate = self;
+    }];
+    [self presentViewController:controller animated:YES completion:nil];
 }
 
 - (IBAction)systemTextBtnClick:(UIButton *)sender {
@@ -148,25 +182,19 @@ typedef NS_ENUM(NSInteger, AAPLAlertsViewControllerTableRow) {
     [self showSecureTextEntryAlert];
 }
 
-#pragma mark - UIAlertViewDelegate
-
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
-    if (alertView.cancelButtonIndex == buttonIndex) {
-        NSLog(@"Alert view clicked with the cancel button index.");
-    }
-    else {
-        NSLog(@"Alert view clicked with button at index %ld.", (long)buttonIndex);
-    }
+- (void)actionClicked:(UIAlertAction * _Nonnull)action {
+    NSLog(@"Alert view clicked with the %@ button.", action.title);
 }
 
-- (BOOL)alertViewShouldEnableFirstOtherButton:(UIAlertView *)alertView {
-    // Enforce a minimum length of >= 5 characters for secure text alert views.
-    if (alertView.alertViewStyle == UIAlertViewStyleSecureTextInput) {
-        return [[alertView textFieldAtIndex:0].text length] >= 5;
+#pragma mark - UITextFieldDelegate
+
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+    NSString *text = [textField.text stringByReplacingCharactersInRange:range withString:string];
+    if (self.otherAction) {
+        self.otherAction.enabled = text.length >= 5;
     }
-    
+
     return YES;
 }
-
 
 @end

--- a/Example/Example/UICategoryTests/GIOLabelAttributeViewController.m
+++ b/Example/Example/UICategoryTests/GIOLabelAttributeViewController.m
@@ -55,37 +55,27 @@
 }
 //弹出浮层测试
 - (IBAction)showAlertTest:(id)sender {
-    [self showalert];
+    [self showAlert];
 }
 
-- (void)showalert {
-    UIAlertController *alert = [UIAlertController  alertControllerWithTitle:@"UIAlertView"
-                                                    message:@"弹出式对话框相关测试！"
-                                           preferredStyle:UIAlertControllerStyleAlert];
-    UIAlertAction *cancel=[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil];
-    UIAlertAction *repopup=[UIAlertAction actionWithTitle:@"重新弹出" style:UIAlertActionStyleDefault handler:nil];
-
-    [alert addAction:cancel];
-    [alert addAction:repopup];
-
-    [self presentViewController:alert animated:YES completion:nil];
-    
-//    [alert addButtonWithTitle:@"重新弹出"];
-//    [alert show];
+- (void)showAlert {
+    UIAlertController *controller = [UIAlertController alertControllerWithTitle:@"UIAlertController"
+                                                                        message:@"弹出式对话框相关测试！"
+                                                                 preferredStyle:UIAlertControllerStyleAlert];
+    __weak typeof(self) weakSelf = self;
+    [controller addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+        NSLog(@"弹出框，单击了按钮：%@", action.title);
+    }]];
+    [controller addAction:[UIAlertAction actionWithTitle:@"重新弹出" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        NSLog(@"弹出框，单击了按钮：%@", action.title);
+        [weakSelf showAlert];
+    }]];
+    [self presentViewController:controller animated:YES completion:nil];
 }
 
 //设置GIO不采集数据
 - (IBAction)growingNotTrack:(id)sender {
     NSLog(@"GrowingIO 不采集点击事件！");
-}
-
-//监听点击事件 代理方法
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
-    if (buttonIndex == 1) {
-        [self showalert];
-    }
-    NSString *btnTitle = [alertView buttonTitleAtIndex:buttonIndex];
-    NSLog(@"弹出框，单击了按钮：%@", btnTitle);
 }
 
 @end


### PR DESCRIPTION
## PR 内容

- 替换 Demo 中的 UIAlertView API 调用，改为 UIAlertController（UIAlertView 于 iOS 8 废弃）

## 测试步骤

* 测试 UI界面->Button&AlertView，各个按钮触发的弹窗是否正常
* 测试 UI界面->AttributeLabel，ShowAlert 按钮触发的弹窗是否正常

## 影响范围

无

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

https://developer.apple.com/documentation/uikit/uialertview
https://developer.apple.com/documentation/uikit/uialertcontroller