### PR TITLE
fix: CI 自动化测试没有全部执行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,12 @@ jobs:
       - name: Before script
         run: |
           pod install
-      - name: Run Tests
-        run: xcodebuild test -workspace  GrowingAnalytics.xcworkspace -scheme Example -destination 'platform=iOS Simulator,name=iPhone 12 Pro' GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
+          
+      - name: Run ExampleTests
+        run: xcodebuild test -workspace GrowingAnalytics.xcworkspace -scheme ExampleTests -destination 'platform=iOS Simulator,name=iPhone 13' GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
+        
+      - name: Run ExampleTests-Protobuf
+        run: xcodebuild test -workspace GrowingAnalytics.xcworkspace -scheme ExampleTests-Protobuf -destination 'platform=iOS Simulator,name=iPhone 13' GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
 
       - name: Upload coverage to Codecov
         if: always()

--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,6 @@ target 'ExampleTests-Protobuf' do
    project 'Example/Example'
    pod 'GrowingAnalytics/Autotracker', :path => './'
    pod 'GrowingAnalytics/Protobuf', :path => './'
-   pod 'KIF', :configurations => ['Debug']
 #   pod 'OHHTTPStubs', :configurations => ['Debug']
 end
 


### PR DESCRIPTION
## PR 内容

fix: CI 自动化测试没有全部执行，目前单元测试有 2 个 Scheme，ExampleTests 和 ExampleTests-Protobuf：
- 使用之前的命令，查看日志可知，ExampleTests 并没有完全执行，仅执行了 ExampleTests-Protobuf
- 因为 Podfile 中 ExampleTests-Protobuf 导入了 KIF 框架，使得 ExampleTests 中的部分单元测试由于 App 启动而执行

## 测试步骤

观察 CI GitHub Action 日志，所有单元测试是否执行

## 影响范围

无

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

