### PR TITLE
fix: setGrowingPageAttributes nil crash

### DIFF
--- a/GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.h
+++ b/GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.h
@@ -27,9 +27,6 @@
 
 @interface UIViewController (GrowingPrivateAttributes)
 
-- (void)mergeGrowingAttributesPvar:(NSDictionary<NSString *,NSObject *> *)growingAttributesPvar;
-- (void)removeGrowingAttributesPvar:(NSString *)key;
-
 @end
 
 

--- a/GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.m
+++ b/GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.m
@@ -34,6 +34,7 @@
 #import "UIViewController+GrowingNode.h"
 #import "UIViewController+GrowingPageHelper.h"
 #import "UIWindow+GrowingNode.h"
+#import "GrowingArgumentChecker.h"
 
 @implementation UIViewController (GrowingNode)
 
@@ -279,7 +280,11 @@ GrowingSafeStringPropertyImplementation(growingPageAlias, setGrowingPageAlias)
 }
 
 - (void)removeGrowingAttributesPvar:(NSString *)key {
-    [self.growingAttributesMutablePvar removeGrowingAttributesVar:key];
+    if (key == nil) {
+        [self.growingAttributesMutablePvar removeAllObjects];
+    } else if (key.length > 0) {
+        [self.growingAttributesMutablePvar removeObjectForKey:key];
+    }
 }
 
 - (NSMutableDictionary<NSString *, NSObject *> *)growingAttributesMutablePvar {
@@ -299,7 +304,7 @@ GrowingSafeStringPropertyImplementation(growingPageAlias, setGrowingPageAlias)
                            [self removeGrowingAttributesPvar:nil];  // remove all
 
                        } else {
-                           if (![growingPageAttributes isValidDictVariable]) {
+                           if ([GrowingArgumentChecker isIllegalAttributes:growingPageAttributes]) {
                                return;
                            }
                            [self mergeGrowingAttributesPvar:growingPageAttributes];

--- a/GrowingTrackerCore/Helpers/NSDictionary+GrowingHelper.h
+++ b/GrowingTrackerCore/Helpers/NSDictionary+GrowingHelper.h
@@ -30,20 +30,10 @@
 
 - (NSString *)growingHelper_jsonString;
 
-- (BOOL)isValidDictVariable;
-
 - (NSString *)growingHelper_queryString;
 
 - (int)intForKey:(NSString *)key fallback:(int)value;
 
 - (long long)longlongForKey:(NSString *)key fallback:(long long)value;
-
-@end
-
-@interface NSMutableDictionary (GrowingHelper)
-
-// return YES: something was changed;
-// return NO: nothing was changed.
-- (BOOL)removeGrowingAttributesVar:(NSString *)key;
 
 @end

--- a/GrowingTrackerCore/Helpers/NSDictionary+GrowingHelper.m
+++ b/GrowingTrackerCore/Helpers/NSDictionary+GrowingHelper.m
@@ -67,17 +67,6 @@
     return [[self growingHelper_jsonData] growingHelper_utf8String];
 }
 
-- (BOOL)isValidDictVariable {
-    for (NSString *k in self) {
-        NSString *key = k;
-        if (![self[key] isKindOfClass:[NSString class]] && ![self[key] isKindOfClass:[NSNumber class]]) {
-            GIOLogError(@"%@ value is not NSString class", key);
-            return NO;
-        }
-    }
-    return YES;
-}
-
 - (NSString *)growingHelper_queryString {
     NSString *query = @"";
 


### PR DESCRIPTION
## PR 内容

- fix: 设置 growingPageAttributes 页面变量为 nil 时，导致崩溃
- fix: GrowingAppDelegateAutotracker.m 合并冗余代码

## 测试步骤

设置 growingPageAttributes 为 nil

## 影响范围

- growingPageAttributes 设置为普通 NSDictionary 对象，是否正常
- growingPageAttributes 设置为 Large NSDictionary 对象，是否正常
- growingPageAttributes 设置为 nil，是否正常

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

