### PR TITLE
fix: 边界情况下，点击退出圈选同时产生事件，可能导致 Crash

### DIFF
--- a/Example/Example/UICategoryTests/Hybrid/gio_hybrideventtest.html
+++ b/Example/Example/UICategoryTests/Hybrid/gio_hybrideventtest.html
@@ -8,6 +8,26 @@
     <meta name="viewport"
         content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover">
     <title>GrowingIO Hybrid In App</title>
+    
+    <script type='text/javascript'>
+      (function(window, document, script, src, namespace) {
+        window[namespace] = window[namespace] || function() {
+          (window[namespace].q = window[namespace].q || []).push(arguments)
+        };
+        script = document.createElement('script');
+        let tag = document.getElementsByTagName('script')[0];
+        script.async = true;
+        script.src = src;
+        tag.parentNode.insertBefore(script, tag);
+      })(window, document, 'script', 'https://assets.giocdn.com/sdk/cdp/gio.js', 'gdp');
+
+      gdp('init', 'bc675c65b3b0290e', 'your dataSourceId', {
+        host: 'api.growingio.com',
+        version: '1.0.0'
+      });
+      gdp('send');
+    </script>
+    
     <script>
         function getWebViewJavascriptBridgeConfiguration() {
             return GrowingWebViewJavascriptBridge.configuration = JSON.parse(window.GrowingWebViewJavascriptBridge.getConfiguration());
@@ -323,13 +343,6 @@
 
         function mockDomChanged() {
             GrowingWebViewJavascriptBridge.onDomChanged();
-        }
-
-        window.GrowingWebViewJavascriptBridge.getDomTree = function (left, top, width, height, zLevel) {
-            console.log("left = " + left + ", top = " + top + ", width = " + width + ", height = " + height + ", zLevel = " + zLevel);
-            return {
-                domtree: "mock"
-            };
         }
     </script>
 </head>

--- a/Modules/WebCircle/GrowingWebCircle.m
+++ b/Modules/WebCircle/GrowingWebCircle.m
@@ -482,6 +482,7 @@ GrowingMod(GrowingWebCircle)
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
 
+    [GrowingHybridBridgeProvider sharedInstance].domChangedDelegate = nil;
     [[GrowingEventManager sharedInstance] removeInterceptor:self];
     [[GrowingApplicationEventManager sharedInstance] removeApplicationEventObserver:self];
     if (self.webSocket) {
@@ -507,8 +508,6 @@ GrowingMod(GrowingWebCircle)
         [alert addOkWithTitle:@"知道了" handler:nil];
         [alert showAlertAnimated:NO];
     }
-
-    [[GrowingEventManager sharedInstance] removeInterceptor:self];
 }
 
 - (BOOL)isRunning {
@@ -551,8 +550,6 @@ GrowingMod(GrowingWebCircle)
         }
     }
 }
-
-#pragma mark - websocket delegate
 
 - (void)webSocketDidOpen:(id <GrowingWebSocketService>)webSocket {
     GIOLogDebug(@"websocket已连接");
@@ -613,8 +610,6 @@ GrowingMod(GrowingWebCircle)
 }
 
 - (void)sendWebcircleWithType:(NSString *)eventType {
-    // this call back run in main thread
-    // so not use lock
     if (!_isReady) {
         return;
     }


### PR DESCRIPTION
## PR 内容

- Crash:
```
*** Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <NSConcreteHashTable: 0x2839ebf20> was mutated while being enumerated.'
*** First throw call stack:
(0x182b7c05c 0x19b096f54 0x182c520e8 0x184328764 0x104a5f3d4 0x104a52ba8 0x104a52ad4 0x104a5f228 0x104a5da18 0x104a52c78 0x18434ae0c 0x182b9e030 0x182baecf0 0x182ae8ff8 0x182aee804 0x182b023c8 0x184325d54 0x104aa18e4 0x18437595c 0x1f2fb1a60 0x1f2fb0f5c)
libc++abi: terminating with uncaught exception of type NSException
dyld4 config: DYLD_LIBRARY_PATH=/usr/lib/system/introspection DYLD_INSERT_LIBRARIES=/Developer/usr/lib/libBacktraceRecording.dylib:/Developer/usr/lib/libMainThreadChecker.dylib:/Developer/Library/PrivateFrameworks/DTDDISupport.framework/libViewDebuggerSupport.dylib
*** Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <NSConcreteHashTable: 0x2839ebf20> was mutated while being enumerated.'
terminating with uncaught exception of type NSException
```
- 原因：在点击退出圈选后，将调用`[[GrowingEventManager sharedInstance] removeInterceptor:self];`清除拦截器，如果此时恰好产生事件并进入了`-[GrowingEventManager postEventBuidler:]`(其内部多次遍历所有拦截器`self.allInterceptor`)，则有可能导致 Crash
- 修改方案：使用线程 GrowingThread 同步执行对`self.allInterceptor`所有读写操作

## 测试步骤

复现步骤：
1. 在`GIOMeasurementProtocolTableViewController.m`中修改以下代码，此步骤模拟用户调用 API 进行埋点，多线程多次调用提升 Crash 概率：
```Objective-C
- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
    NSLog(@"测试类型--测量协议之：%@", cell.textLabel.text);
    
    for (int i = 0; i < 100; i++) {
        dispatch_async(dispatch_get_global_queue(0, 0), ^{
            [GrowingAutotracker.sharedInstance trackCustomEvent:@"test"];
        });
    }
}
```
2. 在`GrowingWebCircle.m`中修改以下代码，此步骤是利用`usleep(useconds_t)`耗时操作，保证清除拦截器时正好在遍历过程中，提升 Crash 概率：
```Objective-C
- (void)growingEventManagerEventTriggered:(NSString *_Nullable)eventType {
    usleep(50 * 1000);
    [self sendWebcircleWithType:eventType];
}
```
3. 扫码圈选，进入"协议/接口"首页，随便点击一行 Cell，并立即点击状态栏，出现弹窗选择退出圈选
4. 此时出现崩溃
5. 使用已修复后的代码再次尝试以上步骤

## 影响范围

修复边界情况下，退出圈选导致 Crash

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

![image](https://user-images.githubusercontent.com/16042670/154222326-c37960b7-b5ab-4a55-8afa-77e58bfce55c.png)

