### PR TITLE
feat: 事件属性支持 list

### DIFF
--- a/Example/Example/MeasurementProtocol/CustomEvent/GIOCustomEventViewController.m
+++ b/Example/Example/MeasurementProtocol/CustomEvent/GIOCustomEventViewController.m
@@ -31,6 +31,11 @@
     self.eventNameTextField.text = [self randomEventName];
         
     [self setupTableView];
+    
+    GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+    [builder setString:@"value" forKey:@"key"];
+    [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+    [GrowingSDK.sharedInstance trackCustomEvent:@"eventName" withAttributesBuilder:builder];
 }
 
 - (void)setupTableView {

--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsCDPTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsCDPTest.m
@@ -132,7 +132,7 @@
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributes:@"value"]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributes:@{@1 : @"value"}]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributes:@{@"key" : @1}]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeLoginUserAttributes];
         XCTAssertEqual(events.count, 0);
     }
@@ -153,10 +153,11 @@
         [MockEventQueue.sharedQueue cleanQueue];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:nil]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@""]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@1]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }
@@ -193,7 +194,66 @@
                                                                 withAttributes:@{@1 : @"value"}]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                                                 withAttributes:@{@"key" : @1}]);
+#pragma clang diagnostic pop
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
+        XCTAssertEqual(events.count, 0);
+    }
+}
+
+- (void)testTrackCustomEventWithAttributesBuilder {
+    {
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                        withAttributesBuilder:builder];
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
+        XCTAssertEqual(events.count, 1);
+        
+        GrowingCustomEvent *event = (GrowingCustomEvent *)events.firstObject;
+        XCTAssertEqualObjects(event.eventName, @"eventName");
+        XCTAssertEqualObjects(event.attributes[@"key"], @"value");
+        XCTAssertEqualObjects(event.attributes[@"key2"], @"value1||value2||value3");
+    }
+    
+    {
+        [MockEventQueue.sharedQueue cleanQueue];
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+#pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:nil
+                                                         withAttributesBuilder:builder]);
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@""
+                                                         withAttributesBuilder:builder]);
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@1
+                                                         withAttributesBuilder:builder]);
+        
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:nil]);
+        
+        GrowingAttributesBuilder *builder2 = GrowingAttributesBuilder.new;
+        [builder2 setString:@1 forKey:@"key"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setString:@"value" forKey:@1];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setArray:@"value" forKey:@"key2"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setArray:@[] forKey:@"key2"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setArray:@[@1, @2, @3] forKey:@"key2"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }
@@ -247,7 +307,7 @@
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                                                        itemKey:@"itemKey"
                                                                         itemId:@1]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }
@@ -299,7 +359,7 @@
         XCTAssertNoThrow([[GrowingTracker sharedInstance] trackCustomEvent:@"eventName"
                                                                    itemKey:@"itemKey"
                                                                     itemId:@1]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }
@@ -375,7 +435,7 @@
                                                                        itemKey:@"itemKey"
                                                                         itemId:@"itemId"
                                                                 withAttributes:@{@"key" : @1}]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }
@@ -449,7 +509,7 @@
                                                                    itemKey:@"itemKey"
                                                                     itemId:@"itemId"
                                                             withAttributes:@{@"key": @1}]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }

--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
@@ -117,7 +117,7 @@
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariables:@"value"]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariables:@{@1 : @"value"}]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariables:@{@"key" : @1}]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeConversionVariables];
         XCTAssertEqual(events.count, 0);
     }
@@ -142,7 +142,7 @@
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributes:@"value"]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributes:@{@1 : @"value"}]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributes:@{@"key" : @1}]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeLoginUserAttributes];
         XCTAssertEqual(events.count, 0);
     }
@@ -167,7 +167,7 @@
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributes:@"value"]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributes:@{@1 : @"value"}]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributes:@{@"key" : @1}]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeVisitorAttributes];
         XCTAssertEqual(events.count, 0);
     }
@@ -188,10 +188,11 @@
         [MockEventQueue.sharedQueue cleanQueue];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:nil]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@""]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@1]);
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }
@@ -228,7 +229,65 @@
                                                                 withAttributes:@{@1 : @"value"}]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                                                 withAttributes:@{@"key" : @1}]);
+#pragma clang diagnostic pop
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
+        XCTAssertEqual(events.count, 0);
+    }
+}
+
+- (void)testTrackCustomEventWithAttributesBuilder {
+    {
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                        withAttributesBuilder:builder];
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
+        XCTAssertEqual(events.count, 1);
+        
+        GrowingCustomEvent *event = (GrowingCustomEvent *)events.firstObject;
+        XCTAssertEqualObjects(event.eventName, @"eventName");
+        XCTAssertEqualObjects(event.attributes[@"key"], @"value");
+    }
+    
+    {
+        [MockEventQueue.sharedQueue cleanQueue];
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+#pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:nil
+                                                         withAttributesBuilder:builder]);
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@""
+                                                         withAttributesBuilder:builder]);
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@1
+                                                         withAttributesBuilder:builder]);
+        
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                                withAttributes:nil]);
+        
+        GrowingAttributesBuilder *builder2 = GrowingAttributesBuilder.new;
+        [builder2 setString:@1 forKey:@"key"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setString:@"value" forKey:@1];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setArray:@"value" forKey:@"key2"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setArray:@[] forKey:@"key2"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+        [builder2 setArray:@[@1, @2, @3] forKey:@"key2"];
+        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                         withAttributesBuilder:builder2]);
+#pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }

--- a/GrowingAnalytics-cdp/GrowingAutotracker/GrowingAutotracker.h
+++ b/GrowingAnalytics-cdp/GrowingAutotracker/GrowingAutotracker.h
@@ -91,14 +91,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param eventName 自定义事件名称
 /// @param itemKey 事件发生关联的物品模型Key
 /// @param itemId 事件发生关联的物品模型ID
-- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId;
+- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId DEPRECATED_MSG_ATTRIBUTE("新版本仅需在属性中关联itemId, 参见维度表数据上报");
 
 /// 发送一个自定义事件
 /// @param eventName 自定义事件名称
 /// @param itemKey 事件发生关联的物品模型Key
 /// @param itemId 事件发生关联的物品模型ID
 /// @param attributes 事件发生时所伴随的维度信息
-- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> * _Nullable)attributes;
+- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> * _Nullable)attributes DEPRECATED_MSG_ATTRIBUTE("新版本仅需在属性中关联itemId, 参见维度表数据上报");
 
 /// 发送一个自定义事件
 /// @param eventName 自定义事件名称

--- a/GrowingAnalytics-cdp/GrowingAutotracker/GrowingAutotracker.h
+++ b/GrowingAnalytics-cdp/GrowingAutotracker/GrowingAutotracker.h
@@ -20,6 +20,7 @@
 #import <UIKit/UIKit.h>
 #import <GrowingAnalytics/GrowingDynamicProxy.h>
 #import <GrowingAnalytics/GrowingAutotrackConfiguration.h>
+#import <GrowingAnalytics/GrowingAttributesBuilder.h>
 #import "GrowingTrackConfiguration+CdpTracker.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -98,6 +99,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param itemId 事件发生关联的物品模型ID
 /// @param attributes 事件发生时所伴随的维度信息
 - (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> * _Nullable)attributes;
+
+/// 发送一个自定义事件
+/// @param eventName 自定义事件名称
+/// @param attributesBuilder 事件发生时所伴随的维度信息构造器
+- (void)trackCustomEvent:(NSString *)eventName withAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
 
 ///-------------------------------
 #pragma mark Unavailable

--- a/GrowingAnalytics-cdp/GrowingTracker/GrowingTracker.h
+++ b/GrowingAnalytics-cdp/GrowingTracker/GrowingTracker.h
@@ -18,6 +18,7 @@
 //  limitations under the License.
 
 #import <GrowingAnalytics/GrowingDynamicProxy.h>
+#import <GrowingAnalytics/GrowingAttributesBuilder.h>
 #import "GrowingTrackConfiguration+CdpTracker.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -96,6 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param itemId 事件发生关联的物品模型ID
 /// @param attributes 事件发生时所伴随的维度信息
 - (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> * _Nullable)attributes;
+
+/// 发送一个自定义事件
+/// @param eventName 自定义事件名称
+/// @param attributesBuilder 事件发生时所伴随的维度信息构造器
+- (void)trackCustomEvent:(NSString *)eventName withAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
 
 ///-------------------------------
 #pragma mark Unavailable

--- a/GrowingAnalytics-cdp/GrowingTracker/GrowingTracker.h
+++ b/GrowingAnalytics-cdp/GrowingTracker/GrowingTracker.h
@@ -89,14 +89,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param eventName 自定义事件名称
 /// @param itemKey 事件发生关联的物品模型Key
 /// @param itemId 事件发生关联的物品模型ID
-- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId;
+- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId DEPRECATED_MSG_ATTRIBUTE("新版本仅需在属性中关联itemId, 参见维度表数据上报");
 
 /// 发送一个自定义事件
 /// @param eventName 自定义事件名称
 /// @param itemKey 事件发生关联的物品模型Key
 /// @param itemId 事件发生关联的物品模型ID
 /// @param attributes 事件发生时所伴随的维度信息
-- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> * _Nullable)attributes;
+- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> * _Nullable)attributes DEPRECATED_MSG_ATTRIBUTE("新版本仅需在属性中关联itemId, 参见维度表数据上报");
 
 /// 发送一个自定义事件
 /// @param eventName 自定义事件名称

--- a/GrowingAnalytics.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/GrowingAnalytics.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -13,7 +13,7 @@
 //  GrowingAnalytics
 //
 //  Created by ___FULLUSERNAME___ on ___DATE___.
-//  Copyright (C) 2021 Beijing Yishu Technology Co., Ltd.
+//  Copyright (C) 2022 Beijing Yishu Technology Co., Ltd.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/GrowingAnalytics/GrowingAutotracker/GrowingAutotracker.h
+++ b/GrowingAnalytics/GrowingAutotracker/GrowingAutotracker.h
@@ -19,6 +19,7 @@
 
 #import "GrowingDynamicProxy.h"
 #import "GrowingAutotrackConfiguration.h"
+#import "GrowingAttributesBuilder.h"
 #import <UIKit/UIKit.h>
 
 @interface GrowingAutotracker : GrowingDynamicProxy
@@ -39,6 +40,11 @@
 /// @param eventName 自定义事件名称
 /// @param attributes 事件发生时所伴随的维度信息
 - (void)trackCustomEvent:(NSString *)eventName withAttributes:(NSDictionary <NSString *, NSString *> *)attributes;
+
+/// 发送一个自定义事件
+/// @param eventName 自定义事件名称
+/// @param attributesBuilder 事件发生时所伴随的维度信息构造器
+- (void)trackCustomEvent:(NSString *)eventName withAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
 
 /// 以登录用户的身份定义用户属性变量，用于用户信息相关分析。
 /// @param attributes 用户属性信息

--- a/GrowingAnalytics/GrowingTracker/GrowingTracker.h
+++ b/GrowingAnalytics/GrowingTracker/GrowingTracker.h
@@ -19,6 +19,7 @@
 
 #import "GrowingDynamicProxy.h"
 #import "GrowingTrackConfiguration.h"
+#import "GrowingAttributesBuilder.h"
 
 @interface GrowingTracker : GrowingDynamicProxy
 
@@ -38,6 +39,11 @@
 /// @param eventName 自定义事件名称
 /// @param attributes 事件发生时所伴随的维度信息
 - (void)trackCustomEvent:(NSString *)eventName withAttributes:(NSDictionary <NSString *, NSString *> *)attributes;
+
+/// 发送一个自定义事件
+/// @param eventName 自定义事件名称
+/// @param attributesBuilder 事件发生时所伴随的维度信息构造器
+- (void)trackCustomEvent:(NSString *)eventName withAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
 
 /// 以登录用户的身份定义用户属性变量，用于用户信息相关分析。
 /// @param attributes 用户属性信息

--- a/GrowingAnalytics/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.h
+++ b/GrowingAnalytics/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.h
@@ -1,0 +1,34 @@
+//
+//  GrowingAttributesBuilder.h
+//  GrowingAnalytics
+//
+//  Created by MazeMao on 2022/3/7.
+//  Copyright (C) 2021 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GrowingAttributesBuilder : NSObject
+
+- (void)setString:(NSString *)value forKey:(NSString *)key;
+
+- (void)setArray:(NSArray<NSString *> *)values forKey:(NSString *)key;
+
+- (NSDictionary *)build;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GrowingAnalytics/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.m
+++ b/GrowingAnalytics/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.m
@@ -1,0 +1,66 @@
+//
+//  GrowingAttributesBuilder.m
+//  GrowingAnalytics
+//
+//  Created by MazeMao on 2022/3/7.
+//  Copyright (C) 2021 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import "GrowingAttributesBuilder.h"
+#import "GrowingLogger.h"
+
+@interface GrowingAttributesBuilder ()
+
+@property (nonatomic, strong) NSMutableDictionary *dictionary;
+
+@end
+
+@implementation GrowingAttributesBuilder
+
+- (void)setString:(NSString *)value forKey:(NSString *)key {
+    [self.dictionary setObject:value forKey:key];
+}
+
+- (void)setArray:(NSArray<NSString *> *)values forKey:(NSString *)key {
+    if (![values isKindOfClass:[NSArray class]]) {
+        return;
+    }
+    
+    for (NSString *value in values) {
+        if (![value isKindOfClass:NSString.class]) {
+            GIOLogError(@"element in array is not kind of NSString class");
+            return;
+        }
+    }
+    
+    NSString *valueString = [values componentsJoinedByString:self.separate];
+    [self.dictionary setObject:valueString forKey:key];
+}
+
+- (NSDictionary *)build {
+    return [NSDictionary dictionaryWithDictionary:self.dictionary];
+}
+
+- (NSMutableDictionary *)dictionary {
+    if (!_dictionary) {
+        _dictionary = NSMutableDictionary.dictionary;
+    }
+    return _dictionary;
+}
+
+- (NSString *)separate {
+    return @"||";
+}
+
+@end

--- a/GrowingAnalytics/GrowingTrackerCore/GrowingRealTracker.h
+++ b/GrowingAnalytics/GrowingTrackerCore/GrowingRealTracker.h
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 
 @class GrowingTrackConfiguration;
+@class GrowingAttributesBuilder;
 
 FOUNDATION_EXPORT NSString *const GrowingTrackerVersionName;
 FOUNDATION_EXPORT const int GrowingTrackerVersionCode;
@@ -44,6 +45,11 @@ FOUNDATION_EXPORT const int GrowingTrackerVersionCode;
 /// @param eventName 自定义事件名称
 /// @param attributes 事件发生时所伴随的维度信息
 - (void)trackCustomEvent:(NSString *)eventName withAttributes:(NSDictionary <NSString *, NSString *> *)attributes;
+
+/// 发送一个自定义事件
+/// @param eventName 自定义事件名称
+/// @param attributesBuilder 事件发生时所伴随的维度信息构造器
+- (void)trackCustomEvent:(NSString *)eventName withAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
 
 /// 以登录用户的身份定义用户属性变量，用于用户信息相关分析。
 /// @param attributes 用户属性信息

--- a/GrowingAnalytics/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingAnalytics/GrowingTrackerCore/GrowingRealTracker.m
@@ -37,6 +37,7 @@
 #import "GrowingModuleManager.h"
 #import "GrowingServiceManager.h"
 #import "GrowingEventManager.h"
+#import "GrowingAttributesBuilder.h"
 
 NSString *const GrowingTrackerVersionName = @"3.3.4";
 const int GrowingTrackerVersionCode = 30304;
@@ -148,6 +149,11 @@ const int GrowingTrackerVersionCode = 30304;
         return;
     }
     [GrowingEventGenerator generateCustomEvent:eventName attributes:attributes];
+}
+
+- (void)trackCustomEvent:(NSString *)eventName withAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder {
+    NSDictionary *attributes = attributesBuilder.build;
+    [self trackCustomEvent:eventName withAttributes:attributes];
 }
 
 - (void)setLoginUserAttributes:(NSDictionary<NSString *, NSString *> *)attributes {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
-  - GrowingAnalytics-cdp/Autotracker (3.3.4-beta):
-    - GrowingAnalytics-cdp/TrackerCore (= 3.3.4-beta)
-    - GrowingAnalytics/AutotrackerCore (= 3.3.4-beta)
-    - GrowingAnalytics/Compression (= 3.3.4-beta)
-    - GrowingAnalytics/Database (= 3.3.4-beta)
-    - GrowingAnalytics/Encryption (= 3.3.4-beta)
-    - GrowingAnalytics/Hybrid (= 3.3.4-beta)
-    - GrowingAnalytics/MobileDebugger (= 3.3.4-beta)
-    - GrowingAnalytics/Network (= 3.3.4-beta)
-    - GrowingAnalytics/WebCircle (= 3.3.4-beta)
-  - GrowingAnalytics-cdp/Tracker (3.3.4-beta):
-    - GrowingAnalytics-cdp/TrackerCore (= 3.3.4-beta)
-    - GrowingAnalytics/Compression (= 3.3.4-beta)
-    - GrowingAnalytics/Database (= 3.3.4-beta)
-    - GrowingAnalytics/Encryption (= 3.3.4-beta)
-    - GrowingAnalytics/MobileDebugger (= 3.3.4-beta)
-    - GrowingAnalytics/Network (= 3.3.4-beta)
-  - GrowingAnalytics-cdp/TrackerCore (3.3.4-beta):
-    - GrowingAnalytics/TrackerCore (= 3.3.4-beta)
-  - GrowingAnalytics/Autotracker (3.3.4-beta):
+  - GrowingAnalytics-cdp/Autotracker (3.3.4):
+    - GrowingAnalytics-cdp/TrackerCore (= 3.3.4)
+    - GrowingAnalytics/AutotrackerCore (= 3.3.4)
+    - GrowingAnalytics/Compression (= 3.3.4)
+    - GrowingAnalytics/Database (= 3.3.4)
+    - GrowingAnalytics/Encryption (= 3.3.4)
+    - GrowingAnalytics/Hybrid (= 3.3.4)
+    - GrowingAnalytics/MobileDebugger (= 3.3.4)
+    - GrowingAnalytics/Network (= 3.3.4)
+    - GrowingAnalytics/WebCircle (= 3.3.4)
+  - GrowingAnalytics-cdp/Tracker (3.3.4):
+    - GrowingAnalytics-cdp/TrackerCore (= 3.3.4)
+    - GrowingAnalytics/Compression (= 3.3.4)
+    - GrowingAnalytics/Database (= 3.3.4)
+    - GrowingAnalytics/Encryption (= 3.3.4)
+    - GrowingAnalytics/MobileDebugger (= 3.3.4)
+    - GrowingAnalytics/Network (= 3.3.4)
+  - GrowingAnalytics-cdp/TrackerCore (3.3.4):
+    - GrowingAnalytics/TrackerCore (= 3.3.4)
+  - GrowingAnalytics/Autotracker (3.3.4):
     - GrowingAnalytics/AutotrackerCore
     - GrowingAnalytics/Compression
     - GrowingAnalytics/Database
@@ -27,42 +27,42 @@ PODS:
     - GrowingAnalytics/MobileDebugger
     - GrowingAnalytics/Network
     - GrowingAnalytics/WebCircle
-  - GrowingAnalytics/AutotrackerCore (3.3.4-beta):
+  - GrowingAnalytics/AutotrackerCore (3.3.4):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Compression (3.3.4-beta):
+  - GrowingAnalytics/Compression (3.3.4):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Database (3.3.4-beta):
+  - GrowingAnalytics/Database (3.3.4):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Encryption (3.3.4-beta):
+  - GrowingAnalytics/Encryption (3.3.4):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Hybrid (3.3.4-beta):
+  - GrowingAnalytics/Hybrid (3.3.4):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/MobileDebugger (3.3.4-beta):
+  - GrowingAnalytics/MobileDebugger (3.3.4):
     - GrowingAnalytics/TrackerCore
     - GrowingAnalytics/WebSocket
-  - GrowingAnalytics/Network (3.3.4-beta):
+  - GrowingAnalytics/Network (3.3.4):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Protobuf (3.3.4-beta):
+  - GrowingAnalytics/Protobuf (3.3.4):
     - GrowingAnalytics/Database
-    - GrowingAnalytics/Protobuf/Proto (= 3.3.4-beta)
+    - GrowingAnalytics/Protobuf/Proto (= 3.3.4)
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Protobuf/Proto (3.3.4-beta):
+  - GrowingAnalytics/Protobuf/Proto (3.3.4):
     - GrowingAnalytics/Database
     - GrowingAnalytics/TrackerCore
     - Protobuf
-  - GrowingAnalytics/Tracker (3.3.4-beta):
+  - GrowingAnalytics/Tracker (3.3.4):
     - GrowingAnalytics/Compression
     - GrowingAnalytics/Database
     - GrowingAnalytics/Encryption
     - GrowingAnalytics/MobileDebugger
     - GrowingAnalytics/Network
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/TrackerCore (3.3.4-beta)
-  - GrowingAnalytics/WebCircle (3.3.4-beta):
+  - GrowingAnalytics/TrackerCore (3.3.4)
+  - GrowingAnalytics/WebCircle (3.3.4):
     - GrowingAnalytics/AutotrackerCore
     - GrowingAnalytics/Hybrid
     - GrowingAnalytics/WebSocket
-  - GrowingAnalytics/WebSocket (3.3.4-beta):
+  - GrowingAnalytics/WebSocket (3.3.4):
     - GrowingAnalytics/TrackerCore
   - KIF (3.8.6):
     - KIF/Core (= 3.8.6)
@@ -97,8 +97,8 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: 277399ece388eeaeb5a8434c3b48cc2794b38a58
-  GrowingAnalytics-cdp: c674919e3db056b9a53517111f7db2f193b46dd6
+  GrowingAnalytics: 6799952a68799fe1630c7d8e86a9afaba7538dd1
+  GrowingAnalytics-cdp: e04501ed6a2a8a9676ccb75b3e80629ad475deb6
   KIF: e2e1bab222b6c9523a0a88caab31f8524fe82404
   Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
   SDCycleScrollView: a0d74c3384caa72bdfc81470bdbc8c14b3e1fbcf

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GrowingIO Autotracker
 
 ## License
 ```
-Copyright (C) 2020 Beijing Yishu Technology Co., Ltd.
+Copyright (C) 2022 Beijing Yishu Technology Co., Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## PR 内容

事件属性支持 list
示例代码如下：
```Objective-C
GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
[builder setString:@"value" forKey:@"key"];
[builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
[GrowingAutotracker.sharedInstance trackCustomEvent:@"eventName" withAttributesBuilder:builder];
```

## 测试步骤

- 如示例代码，测试 CUSTOM 事件属性添加 Array 上报是否正常
- 测试边界情况（类型不符等，见单测）下，该接口调用是否有所提示，且不报错
- 单元测试通过

## 影响范围

- CUSTOM 事件属性上报

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

无