### PR TITLE
feat: CUSTOM 事件属性支持 NSArray<ObjectType>，优化参数判断，补充单元测试

### DIFF
--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsCDPTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsCDPTest.m
@@ -205,6 +205,10 @@
         GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
         [builder setString:@"value" forKey:@"key"];
         [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setArray:@[@1, @2, @3] forKey:@"key3"];
+        [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
+        [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
+        [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
         [[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                         withAttributesBuilder:builder];
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
@@ -214,6 +218,12 @@
         XCTAssertEqualObjects(event.eventName, @"eventName");
         XCTAssertEqualObjects(event.attributes[@"key"], @"value");
         XCTAssertEqualObjects(event.attributes[@"key2"], @"value1||value2||value3");
+        XCTAssertEqualObjects(event.attributes[@"key3"], @"1||2||3");
+        XCTAssertEqualObjects(event.attributes[@"key4"], @"(\n    1\n)||(\n    2\n)||(\n    3\n)");
+        XCTAssertEqualObjects(event.attributes[@"key5"], @"{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}");
+        XCTAssertNotNil(event.attributes[@"key6"]);
     }
     
     {
@@ -234,31 +244,80 @@
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                                          withAttributesBuilder:nil]);
         
-        GrowingAttributesBuilder *builder2 = GrowingAttributesBuilder.new;
-        [builder2 setString:@1 forKey:@"key"];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setString:@"value" forKey:@1];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setArray:@"value" forKey:@"key2"];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setArray:@[] forKey:@"key2"];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setArray:@[@1, @2, @3] forKey:@"key2"];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@1 forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[] forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@"value" forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
 #pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);
     }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)testTrackCustomEventWithItem {
     // Autotracker
     {
@@ -514,6 +573,7 @@
         XCTAssertEqual(events.count, 0);
     }
 }
+#pragma clang diagnostic pop
 
 - (void)testGetDeviceId {
     XCTAssertNotNil([[GrowingAutotracker sharedInstance] getDeviceId]);

--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
@@ -240,6 +240,10 @@
         GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
         [builder setString:@"value" forKey:@"key"];
         [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setArray:@[@1, @2, @3] forKey:@"key3"];
+        [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
+        [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
+        [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
         [[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                         withAttributesBuilder:builder];
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
@@ -248,6 +252,13 @@
         GrowingCustomEvent *event = (GrowingCustomEvent *)events.firstObject;
         XCTAssertEqualObjects(event.eventName, @"eventName");
         XCTAssertEqualObjects(event.attributes[@"key"], @"value");
+        XCTAssertEqualObjects(event.attributes[@"key2"], @"value1||value2||value3");
+        XCTAssertEqualObjects(event.attributes[@"key3"], @"1||2||3");
+        XCTAssertEqualObjects(event.attributes[@"key4"], @"(\n    1\n)||(\n    2\n)||(\n    3\n)");
+        XCTAssertEqualObjects(event.attributes[@"key5"], @"{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}");
+        XCTAssertNotNil(event.attributes[@"key6"]);
     }
     
     {
@@ -266,27 +277,74 @@
                                                          withAttributesBuilder:builder]);
         
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                                withAttributes:nil]);
+                                                         withAttributesBuilder:nil]);
         
-        GrowingAttributesBuilder *builder2 = GrowingAttributesBuilder.new;
-        [builder2 setString:@1 forKey:@"key"];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setString:@"value" forKey:@1];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setArray:@"value" forKey:@"key2"];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setArray:@[] forKey:@"key2"];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
-        [builder2 setArray:@[@1, @2, @3] forKey:@"key2"];
-        XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                         withAttributesBuilder:builder2]);
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@1 forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[] forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@"value" forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
+                                                             withAttributesBuilder:builder]);
+        }
 #pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
         XCTAssertEqual(events.count, 0);

--- a/GrowingAnalytics/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.h
+++ b/GrowingAnalytics/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.h
@@ -21,13 +21,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface GrowingAttributesBuilder : NSObject
+@interface GrowingAttributesBuilder<__covariant ObjectType> : NSObject
 
 - (void)setString:(NSString *)value forKey:(NSString *)key;
 
-- (void)setArray:(NSArray<NSString *> *)values forKey:(NSString *)key;
+- (void)setArray:(NSArray<ObjectType> *)values forKey:(NSString *)key;
 
-- (NSDictionary *)build;
+- (nullable NSDictionary *)build;
 
 @end
 

--- a/GrowingAnalytics/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.m
+++ b/GrowingAnalytics/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.m
@@ -29,26 +29,42 @@
 @implementation GrowingAttributesBuilder
 
 - (void)setString:(NSString *)value forKey:(NSString *)key {
-    [self.dictionary setObject:value forKey:key];
-}
-
-- (void)setArray:(NSArray<NSString *> *)values forKey:(NSString *)key {
-    if (![values isKindOfClass:[NSArray class]]) {
+    if (![key isKindOfClass:[NSString class]]
+        || key.length == 0
+        || ![value isKindOfClass:[NSString class]]) {
         return;
     }
     
-    for (NSString *value in values) {
-        if (![value isKindOfClass:NSString.class]) {
-            GIOLogError(@"element in array is not kind of NSString class");
-            return;
+    [self.dictionary setObject:value forKey:key];
+}
+
+- (void)setArray:(NSArray<NSObject *> *)values forKey:(NSString *)key {
+    if (![key isKindOfClass:[NSString class]]
+        || key.length == 0
+        || ![values isKindOfClass:[NSArray class]]
+        || values.count == 0) {
+        return;
+    }
+    
+    NSMutableArray *array = NSMutableArray.array;
+    for (NSObject *value in values) {
+        if ([value isKindOfClass:NSString.class]) {
+            [array addObject:value];
+        } else if ([value isKindOfClass:NSNumber.class]) {
+            [array addObject:value];
+        } else {
+            [array addObject:value.description];
         }
     }
     
-    NSString *valueString = [values componentsJoinedByString:self.separate];
+    NSString *valueString = [array componentsJoinedByString:self.separate];
     [self.dictionary setObject:valueString forKey:key];
 }
 
-- (NSDictionary *)build {
+- (nullable NSDictionary *)build {
+    if (self.dictionary.count == 0) {
+        return nil;
+    }
     return [NSDictionary dictionaryWithDictionary:self.dictionary];
 }
 


### PR DESCRIPTION
## PR 内容

- CUSTOM 事件属性支持 NSArray<ObjectType>，优化参数判断，补充单元测试
**其中 Key 必须是 NSString 类型，且不能为空字符串**
示例代码如下：
```Objective-C
GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
[builder setString:@"value" forKey:@"key"];
[builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
[builder setArray:@[@1, @2, @3] forKey:@"key3"];
[builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
[builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
[builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
[[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                withAttributesBuilder:builder];
```
- **补充** https://github.com/growingio/growingio-sdk-ios-autotracker/pull/195

## 测试步骤

- 如示例代码，测试 CUSTOM 事件属性添加 Array 上报是否正常
- 测试边界情况（类型不符、参数为空等，见单测）下，接口调用不报错
- 单元测试通过

## 影响范围

- CUSTOM 事件属性上报

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

无

