### PR TITLE
fix: GrowingEventManager 在 loadLocalServices 之前初始化将导致数据库创建失败，事件无法入库

### DIFF
--- a/GrowingTrackerCore/Event/GrowingEventManager.h
+++ b/GrowingTrackerCore/Event/GrowingEventManager.h
@@ -56,8 +56,8 @@
 
 + (_Nonnull instancetype)sharedInstance;
 
-/// 配置事件发送通道
-- (void)configChannels;
+/// 配置事件管理者
+- (void)configManager;
 
 /// 开启事件发送定时器
 - (void)startTimerSend;

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -69,7 +69,7 @@ const int GrowingTrackerVersionCode = 30305;
         [[GrowingServiceManager sharedInstance] loadLocalServices];
         [[GrowingModuleManager sharedInstance] triggerEvent:GrowingMInitEvent];
         // 各个Module初始化init之后再进行事件定时发送
-        [[GrowingEventManager sharedInstance] configChannels];
+        [[GrowingEventManager sharedInstance] configManager];
         [[GrowingEventManager sharedInstance] startTimerSend];
         [self versionPrint];
         [self filterLogPrint];


### PR DESCRIPTION
## PR 内容

- fix: GrowingEventManager 在 loadLocalServices 之前初始化将导致数据库创建失败，事件无法入库
 
  SDK 3.3.2 版本及以上，同时集成 [GrowingAnalytics-upgrade](https://github.com/growingio/growingio-sdk-ios-autotracker-upgrade) 以迁移 SDK 2to3 时，会导致埋点事件以及部分无埋点事件丢失
  - 原因：
  
    https://github.com/growingio/growingio-sdk-ios-autotracker/pull/172 将**所有预置 Services 注册(包括 Database Service)** 延后至 SDK 初始化时，而 GrowingAnalytics-upgrade 在 **+load 时期**调用了`+[GrowingEventManager sharedInstance]`提前初始化数据库，导致数据库因未配置 Services Class 创建失败
  - 修改方案：
  
    将`+[GrowingEventManager sharedInstance]`中**初始化数据库、初始化流量控制变量**等逻辑迁移到`-[GrowingEventManager configManager]`，保证`+[GrowingEventManager sharedInstance]`的调用不会对事件存储与发送造成影响

## 测试步骤

- Podfile 集成：
  ```ruby
  pod 'GrowingAnalytics-upgrade/Autotracker-upgrade-2to3-cdp'
  pod 'GrowingAnalytics-cdp/Autotracker'
  ```
- 执行 pod install
- 通过抓包工具或 GioKit 验证事件是否正常入库与发送

## 影响范围

`+[GrowingEventManager sharedInstance]`初始化逻辑

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

- `-[GrowingEventManager configManager]`在 SDK 初始化逻辑中
- 单独使用本 SDK 无影响

