### PR TITLE
feat: LOGIN_USER_ATTRIBUTES 事件属性支持 NSArray<ObjectType>

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -1441,6 +1441,7 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-06ecc7cf/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingToolsKit/GrowingToolsKit.framework",
 				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/SDCycleScrollView/SDCycleScrollView.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
@@ -1448,6 +1449,7 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingToolsKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDCycleScrollView.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",

--- a/Example/Example/AppDelegate.m
+++ b/Example/Example/AppDelegate.m
@@ -8,6 +8,7 @@
 
 #import "AppDelegate.h"
 #import <AppTrackingTransparency/AppTrackingTransparency.h>
+#import <GrowingToolsKit/GrowingToolsKit.h>
 
 static NSString *const kGrowingProjectId = @"bc675c65b3b0290e";
 
@@ -18,6 +19,8 @@ static NSString *const kGrowingProjectId = @"bc675c65b3b0290e";
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    [GrowingToolsKit start];
+    
     // Config GrowingIO
     GrowingSDKConfiguration *configuration = [GrowingSDKConfiguration configurationWithProjectId:kGrowingProjectId];
     configuration.debugEnabled = YES;

--- a/Example/Example/MeasurementProtocol/AttributesEvent/GIOAttributesTrackViewController.m
+++ b/Example/Example/MeasurementProtocol/AttributesEvent/GIOAttributesTrackViewController.m
@@ -99,12 +99,30 @@
 - (void)trackEventWithAttributes:(NSDictionary *)atts {
     if ([self.eventType isEqualToString:@"LOGIN_USER_ATTRIBUTES"]) {
         [[GrowingSDK sharedInstance] setLoginUserAttributes:atts];
+        
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setString:@"LOGIN_USER_ATTRIBUTES" forKey:@"type"];
+        [GrowingSDK.sharedInstance setLoginUserAttributesWithAttributesBuilder:builder];
 
     } else if ([self.eventType isEqualToString:@"CONVERSION_VARIABLES"]) {
         [[GrowingSDK sharedInstance] setConversionVariables:atts];
+        
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setString:@"CONVERSION_VARIABLES" forKey:@"type"];
+        [GrowingSDK.sharedInstance setConversionVariablesWithAttributesBuilder:builder];
 
     } else if ([self.eventType isEqualToString:@"VISITOR_ATTRIBUTES"]) {
         [[GrowingSDK sharedInstance] setVisitorAttributes:atts];
+        
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setString:@"VISITOR_ATTRIBUTES" forKey:@"type"];
+        [GrowingSDK.sharedInstance setVisitorAttributesWithAttributesBuilder:builder];
     }
 
     NSLog(@"track %@ 事件，attributes:%@", self.eventType, atts);

--- a/Example/Example/MeasurementProtocol/CustomEvent/GIOCustomEventViewController.m
+++ b/Example/Example/MeasurementProtocol/CustomEvent/GIOCustomEventViewController.m
@@ -32,11 +32,6 @@
     self.eventNameTextField.text = [self randomEventName];
         
     [self setupTableView];
-    
-    GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-    [builder setString:@"value" forKey:@"key"];
-    [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
-    [GrowingSDK.sharedInstance trackCustomEvent:@"eventName" withAttributesBuilder:builder];
 }
 
 - (void)setupTableView {
@@ -58,9 +53,13 @@
     
     if (atts.count > 0) {
 
-        [[GrowingSDK sharedInstance] trackCustomEvent:eventName
-                   withAttributes:atts];
+        [[GrowingSDK sharedInstance] trackCustomEvent:eventName withAttributes:atts];
         
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setString:@"CUSTOM" forKey:@"type"];
+        [[GrowingSDK sharedInstance] trackCustomEvent:eventName withAttributesBuilder:builder];
         NSLog(@"Track事件，eventName:%@, attributes:%@", eventName, atts);
 
     } else {

--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsCDPTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsCDPTest.m
@@ -147,6 +147,8 @@
         [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
         [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
         [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [builder setArray:@[NSNull.new, NSNull.new, NSNull.new] forKey:@"key7"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
         [[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder];
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeLoginUserAttributes];
         XCTAssertEqual(events.count, 1);
@@ -160,6 +162,8 @@
                                                          @"||{\n    value = key;\n}"
                                                          @"||{\n    value = key;\n}");
         XCTAssertNotNil(event.attributes[@"key6"]);
+        XCTAssertEqualObjects(event.attributes[@"key7"], @"||||");
+        XCTAssertEqualObjects(event.attributes[@""], @"value1||value2||value3");
     }
     
     {
@@ -187,11 +191,6 @@
         }
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setString:@"value" forKey:@""];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setString:@"value" forKey:@1];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
         }
@@ -213,11 +212,6 @@
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
         }
         {
@@ -302,6 +296,8 @@
         [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
         [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
         [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [builder setArray:@[NSNull.new, NSNull.new, NSNull.new] forKey:@"key7"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
         [[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                         withAttributesBuilder:builder];
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
@@ -317,6 +313,8 @@
                                                          @"||{\n    value = key;\n}"
                                                          @"||{\n    value = key;\n}");
         XCTAssertNotNil(event.attributes[@"key6"]);
+        XCTAssertEqualObjects(event.attributes[@"key7"], @"||||");
+        XCTAssertEqualObjects(event.attributes[@""], @"value1||value2||value3");
     }
     
     {
@@ -357,12 +355,6 @@
         }
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setString:@"value" forKey:@""];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                             withAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setString:@"value" forKey:@1];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                                              withAttributesBuilder:builder]);
@@ -388,12 +380,6 @@
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                             withAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                                              withAttributesBuilder:builder]);
         }

--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsCDPTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsCDPTest.m
@@ -138,6 +138,99 @@
     }
 }
 
+- (void)testSetLoginUserAttributesWithAttributesBuilder {
+    {
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setArray:@[@1, @2, @3] forKey:@"key3"];
+        [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
+        [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
+        [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder];
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeLoginUserAttributes];
+        XCTAssertEqual(events.count, 1);
+        
+        GrowingLoginUserAttributesEvent *event = (GrowingLoginUserAttributesEvent *)events.firstObject;
+        XCTAssertEqualObjects(event.attributes[@"key"], @"value");
+        XCTAssertEqualObjects(event.attributes[@"key2"], @"value1||value2||value3");
+        XCTAssertEqualObjects(event.attributes[@"key3"], @"1||2||3");
+        XCTAssertEqualObjects(event.attributes[@"key4"], @"(\n    1\n)||(\n    2\n)||(\n    3\n)");
+        XCTAssertEqualObjects(event.attributes[@"key5"], @"{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}");
+        XCTAssertNotNil(event.attributes[@"key6"]);
+    }
+    
+    {
+        [MockEventQueue.sharedQueue cleanQueue];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+#pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+        {
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:nil]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@1 forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[] forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@"value" forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+#pragma clang diagnostic pop
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeLoginUserAttributes];
+        XCTAssertEqual(events.count, 0);
+    }
+}
+
 - (void)testTrackCustomEvent {
     {
         [[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"];

--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
@@ -132,6 +132,8 @@
         [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
         [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
         [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [builder setArray:@[NSNull.new, NSNull.new, NSNull.new] forKey:@"key7"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
         [[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder];
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeConversionVariables];
         XCTAssertEqual(events.count, 1);
@@ -145,6 +147,8 @@
                                                          @"||{\n    value = key;\n}"
                                                          @"||{\n    value = key;\n}");
         XCTAssertNotNil(event.attributes[@"key6"]);
+        XCTAssertEqualObjects(event.attributes[@"key7"], @"||||");
+        XCTAssertEqualObjects(event.attributes[@""], @"value1||value2||value3");
     }
     
     {
@@ -172,11 +176,6 @@
         }
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setString:@"value" forKey:@""];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setString:@"value" forKey:@1];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
         }
@@ -198,11 +197,6 @@
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
         }
         {
@@ -250,6 +244,8 @@
         [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
         [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
         [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [builder setArray:@[NSNull.new, NSNull.new, NSNull.new] forKey:@"key7"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
         [[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder];
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeLoginUserAttributes];
         XCTAssertEqual(events.count, 1);
@@ -263,6 +259,8 @@
                                                          @"||{\n    value = key;\n}"
                                                          @"||{\n    value = key;\n}");
         XCTAssertNotNil(event.attributes[@"key6"]);
+        XCTAssertEqualObjects(event.attributes[@"key7"], @"||||");
+        XCTAssertEqualObjects(event.attributes[@""], @"value1||value2||value3");
     }
     
     {
@@ -290,11 +288,6 @@
         }
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setString:@"value" forKey:@""];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setString:@"value" forKey:@1];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
         }
@@ -316,11 +309,6 @@
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
         }
         {
@@ -368,6 +356,8 @@
         [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
         [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
         [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [builder setArray:@[NSNull.new, NSNull.new, NSNull.new] forKey:@"key7"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
         [[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder];
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeVisitorAttributes];
         XCTAssertEqual(events.count, 1);
@@ -381,6 +371,8 @@
                                                          @"||{\n    value = key;\n}"
                                                          @"||{\n    value = key;\n}");
         XCTAssertNotNil(event.attributes[@"key6"]);
+        XCTAssertEqualObjects(event.attributes[@"key7"], @"||||");
+        XCTAssertEqualObjects(event.attributes[@""], @"value1||value2||value3");
     }
     
     {
@@ -408,11 +400,6 @@
         }
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setString:@"value" forKey:@""];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setString:@"value" forKey:@1];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
         }
@@ -434,11 +421,6 @@
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
         }
         {
@@ -523,6 +505,8 @@
         [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
         [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
         [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [builder setArray:@[NSNull.new, NSNull.new, NSNull.new] forKey:@"key7"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
         [[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                         withAttributesBuilder:builder];
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeCustom];
@@ -538,6 +522,8 @@
                                                          @"||{\n    value = key;\n}"
                                                          @"||{\n    value = key;\n}");
         XCTAssertNotNil(event.attributes[@"key6"]);
+        XCTAssertEqualObjects(event.attributes[@"key7"], @"||||");
+        XCTAssertEqualObjects(event.attributes[@""], @"value1||value2||value3");
     }
     
     {
@@ -578,12 +564,6 @@
         }
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setString:@"value" forKey:@""];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                             withAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setString:@"value" forKey:@1];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                                              withAttributesBuilder:builder]);
@@ -609,12 +589,6 @@
         {
             GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
             [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
-            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
-                                                             withAttributesBuilder:builder]);
-        }
-        {
-            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
-            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
             XCTAssertNoThrow([[GrowingAutotracker sharedInstance] trackCustomEvent:@"eventName"
                                                              withAttributesBuilder:builder]);
         }

--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
@@ -123,6 +123,99 @@
     }
 }
 
+- (void)testSetConversionVariablesWithAttributesBuilder {
+    {
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setArray:@[@1, @2, @3] forKey:@"key3"];
+        [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
+        [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
+        [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder];
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeConversionVariables];
+        XCTAssertEqual(events.count, 1);
+        
+        GrowingConversionVariableEvent *event = (GrowingConversionVariableEvent *)events.firstObject;
+        XCTAssertEqualObjects(event.attributes[@"key"], @"value");
+        XCTAssertEqualObjects(event.attributes[@"key2"], @"value1||value2||value3");
+        XCTAssertEqualObjects(event.attributes[@"key3"], @"1||2||3");
+        XCTAssertEqualObjects(event.attributes[@"key4"], @"(\n    1\n)||(\n    2\n)||(\n    3\n)");
+        XCTAssertEqualObjects(event.attributes[@"key5"], @"{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}");
+        XCTAssertNotNil(event.attributes[@"key6"]);
+    }
+    
+    {
+        [MockEventQueue.sharedQueue cleanQueue];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+#pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+        {
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:nil]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@1 forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[] forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@"value" forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setConversionVariablesWithAttributesBuilder:builder]);
+        }
+#pragma clang diagnostic pop
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeConversionVariables];
+        XCTAssertEqual(events.count, 0);
+    }
+}
+
 - (void)testSetLoginUserAttributes {
     {
         [[GrowingAutotracker sharedInstance] setLoginUserAttributes:@{@"key" : @"value"}];
@@ -148,6 +241,99 @@
     }
 }
 
+- (void)testSetLoginUserAttributesWithAttributesBuilder {
+    {
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setArray:@[@1, @2, @3] forKey:@"key3"];
+        [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
+        [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
+        [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder];
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeLoginUserAttributes];
+        XCTAssertEqual(events.count, 1);
+        
+        GrowingLoginUserAttributesEvent *event = (GrowingLoginUserAttributesEvent *)events.firstObject;
+        XCTAssertEqualObjects(event.attributes[@"key"], @"value");
+        XCTAssertEqualObjects(event.attributes[@"key2"], @"value1||value2||value3");
+        XCTAssertEqualObjects(event.attributes[@"key3"], @"1||2||3");
+        XCTAssertEqualObjects(event.attributes[@"key4"], @"(\n    1\n)||(\n    2\n)||(\n    3\n)");
+        XCTAssertEqualObjects(event.attributes[@"key5"], @"{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}");
+        XCTAssertNotNil(event.attributes[@"key6"]);
+    }
+    
+    {
+        [MockEventQueue.sharedQueue cleanQueue];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+#pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+        {
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:nil]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@1 forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[] forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@"value" forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder]);
+        }
+#pragma clang diagnostic pop
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeLoginUserAttributes];
+        XCTAssertEqual(events.count, 0);
+    }
+}
+
 - (void)testSetVisitorAttributes {
     {
         [[GrowingAutotracker sharedInstance] setVisitorAttributes:@{@"key" : @"value"}];
@@ -167,6 +353,99 @@
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributes:@"value"]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributes:@{@1 : @"value"}]);
         XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributes:@{@"key" : @1}]);
+#pragma clang diagnostic pop
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeVisitorAttributes];
+        XCTAssertEqual(events.count, 0);
+    }
+}
+
+- (void)testSetVisitorAttributesWithAttributesBuilder {
+    {
+        GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+        [builder setString:@"value" forKey:@"key"];
+        [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
+        [builder setArray:@[@1, @2, @3] forKey:@"key3"];
+        [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
+        [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
+        [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
+        [[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder];
+        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeVisitorAttributes];
+        XCTAssertEqual(events.count, 1);
+        
+        GrowingVisitorAttributesEvent *event = (GrowingVisitorAttributesEvent *)events.firstObject;
+        XCTAssertEqualObjects(event.attributes[@"key"], @"value");
+        XCTAssertEqualObjects(event.attributes[@"key2"], @"value1||value2||value3");
+        XCTAssertEqualObjects(event.attributes[@"key3"], @"1||2||3");
+        XCTAssertEqualObjects(event.attributes[@"key4"], @"(\n    1\n)||(\n    2\n)||(\n    3\n)");
+        XCTAssertEqualObjects(event.attributes[@"key5"], @"{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}"
+                                                         @"||{\n    value = key;\n}");
+        XCTAssertNotNil(event.attributes[@"key6"]);
+    }
+    
+    {
+        [MockEventQueue.sharedQueue cleanQueue];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+#pragma clang diagnostic ignored "-Wobjc-literal-conversion"
+        {
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:nil]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@1 forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setString:@"value" forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:nil forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[] forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@"value" forKey:@"key"];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:nil];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
+        {
+            GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
+            [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@1];
+            XCTAssertNoThrow([[GrowingAutotracker sharedInstance] setVisitorAttributesWithAttributesBuilder:builder]);
+        }
 #pragma clang diagnostic pop
         NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeVisitorAttributes];
         XCTAssertEqual(events.count, 0);

--- a/GrowingAutotracker-cdp/GrowingAutotracker.h
+++ b/GrowingAutotracker-cdp/GrowingAutotracker.h
@@ -71,6 +71,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param attributes 用户属性信息
 - (void)setLoginUserAttributes:(NSDictionary<NSString *, NSString *> *)attributes;
 
+/// 以登录用户的身份定义用户属性变量，用于用户信息相关分析。
+/// @param attributesBuilder 用户属性信息构造器
+- (void)setLoginUserAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
+
 /// 同步获取设备id，又称为匿名用户id，SDK 自动生成用来定义唯一设备。
 - (NSString *)getDeviceId;
 

--- a/GrowingAutotracker/GrowingAutotracker.h
+++ b/GrowingAutotracker/GrowingAutotracker.h
@@ -50,13 +50,25 @@
 /// @param attributes 用户属性信息
 - (void)setLoginUserAttributes:(NSDictionary<NSString *, NSString *> *)attributes;
 
+/// 以登录用户的身份定义用户属性变量，用于用户信息相关分析。
+/// @param attributesBuilder 用户属性信息构造器
+- (void)setLoginUserAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
+
 /// 以访客的身份定义用户属性变量，也可用于A/B测试上传标签。
 /// @param attributes 用户属性信息
 - (void)setVisitorAttributes:(NSDictionary<NSString *, NSString *> *)attributes;
 
+/// 以访客的身份定义用户属性变量，也可用于A/B测试上传标签。
+/// @param attributesBuilder 用户属性信息构造器
+- (void)setVisitorAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
+
 /// 发送一个转化信息用于高级归因分析，在添加代码之前必须在打点管理界面上声明转化变量。
-/// @param variables 用户属性信息
+/// @param variables 转化变量信息
 - (void)setConversionVariables:(NSDictionary <NSString *, NSString *> *)variables;
+
+/// 发送一个转化信息用于高级归因分析，在添加代码之前必须在打点管理界面上声明转化变量。
+/// @param attributesBuilder 转化变量信息构造器
+- (void)setConversionVariablesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
 
 /// 支持设置userId的类型, 存储方式与userId保持一致, userKey默认为null
 /// @param userId 用户ID

--- a/GrowingTracker-cdp/GrowingTracker.h
+++ b/GrowingTracker-cdp/GrowingTracker.h
@@ -69,6 +69,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param attributes 用户属性信息
 - (void)setLoginUserAttributes:(NSDictionary<NSString *, NSString *> *)attributes;
 
+/// 以登录用户的身份定义用户属性变量，用于用户信息相关分析。
+/// @param attributesBuilder 用户属性信息构造器
+- (void)setLoginUserAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
+
 /// 同步获取设备id，又称为匿名用户id，SDK 自动生成用来定义唯一设备。
 - (NSString *)getDeviceId;
 

--- a/GrowingTracker/GrowingTracker.h
+++ b/GrowingTracker/GrowingTracker.h
@@ -49,13 +49,25 @@
 /// @param attributes 用户属性信息
 - (void)setLoginUserAttributes:(NSDictionary<NSString *, NSString *> *)attributes;
 
+/// 以登录用户的身份定义用户属性变量，用于用户信息相关分析。
+/// @param attributesBuilder 用户属性信息构造器
+- (void)setLoginUserAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
+
 /// 以访客的身份定义用户属性变量，也可用于A/B测试上传标签。
 /// @param attributes 用户属性信息
 - (void)setVisitorAttributes:(NSDictionary<NSString *, NSString *> *)attributes;
 
+/// 以访客的身份定义用户属性变量，也可用于A/B测试上传标签。
+/// @param attributesBuilder 用户属性信息构造器
+- (void)setVisitorAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
+
 /// 发送一个转化信息用于高级归因分析，在添加代码之前必须在打点管理界面上声明转化变量。
-/// @param variables 用户属性信息
+/// @param variables 转化变量信息
 - (void)setConversionVariables:(NSDictionary <NSString *, NSString *> *)variables;
+
+/// 发送一个转化信息用于高级归因分析，在添加代码之前必须在打点管理界面上声明转化变量。
+/// @param attributesBuilder 转化变量信息构造器
+- (void)setConversionVariablesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
 
 /// 支持设置userId的类型, 存储方式与userId保持一致, userKey默认为null
 /// @param userId 用户ID

--- a/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.m
+++ b/GrowingTrackerCore/Event/Base/GrowingAttributesBuilder.m
@@ -30,7 +30,6 @@
 
 - (void)setString:(NSString *)value forKey:(NSString *)key {
     if (![key isKindOfClass:[NSString class]]
-        || key.length == 0
         || ![value isKindOfClass:[NSString class]]) {
         return;
     }
@@ -40,7 +39,6 @@
 
 - (void)setArray:(NSArray<NSObject *> *)values forKey:(NSString *)key {
     if (![key isKindOfClass:[NSString class]]
-        || key.length == 0
         || ![values isKindOfClass:[NSArray class]]
         || values.count == 0) {
         return;
@@ -52,6 +50,8 @@
             [array addObject:value];
         } else if ([value isKindOfClass:NSNumber.class]) {
             [array addObject:value];
+        } else if ([value isKindOfClass:NSNull.class]) {
+            [array addObject:@""];
         } else {
             [array addObject:value.description];
         }

--- a/GrowingTrackerCore/GrowingRealTracker.h
+++ b/GrowingTrackerCore/GrowingRealTracker.h
@@ -55,13 +55,25 @@ FOUNDATION_EXPORT const int GrowingTrackerVersionCode;
 /// @param attributes 用户属性信息
 - (void)setLoginUserAttributes:(NSDictionary<NSString *, NSString *> *)attributes;
 
+/// 以登录用户的身份定义用户属性变量，用于用户信息相关分析。
+/// @param attributesBuilder 用户属性信息构造器
+- (void)setLoginUserAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
+
 /// 以访客的身份定义用户属性变量，也可用于A/B测试上传标签。
 /// @param attributes 用户属性信息
 - (void)setVisitorAttributes:(NSDictionary<NSString *, NSString *> *)attributes;
 
+/// 以访客的身份定义用户属性变量，也可用于A/B测试上传标签。
+/// @param attributesBuilder 用户属性信息构造器
+- (void)setVisitorAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
+
 /// 发送一个转化信息用于高级归因分析，在添加代码之前必须在打点管理界面上声明转化变量。
-/// @param variables 用户属性信息
+/// @param variables 转化变量信息
 - (void)setConversionVariables:(NSDictionary <NSString *, NSString *> *)variables;
+
+/// 发送一个转化信息用于高级归因分析，在添加代码之前必须在打点管理界面上声明转化变量。
+/// @param attributesBuilder 转化变量信息构造器
+- (void)setConversionVariablesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder;
 
 /// 当用户登录之后调用setLoginUserId API，设置登录用户ID。
 /// @param userId 用户ID

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -163,6 +163,11 @@ const int GrowingTrackerVersionCode = 30305;
     [GrowingEventGenerator generateLoginUserAttributesEvent:attributes];
 }
 
+- (void)setLoginUserAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder {
+    NSDictionary *attributes = attributesBuilder.build;
+    [self setLoginUserAttributes:attributes];
+}
+
 - (void)setVisitorAttributes:(NSDictionary<NSString *, NSString *> *)attributes {
     if ([GrowingArgumentChecker isIllegalAttributes:attributes]) {
         return;
@@ -170,11 +175,21 @@ const int GrowingTrackerVersionCode = 30305;
     [GrowingEventGenerator generateVisitorAttributesEvent:attributes];
 }
 
+- (void)setVisitorAttributesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder {
+    NSDictionary *attributes = attributesBuilder.build;
+    [self setVisitorAttributes:attributes];
+}
+
 - (void)setConversionVariables:(NSDictionary<NSString *, NSString *> *)variables {
     if ([GrowingArgumentChecker isIllegalAttributes:variables]) {
         return;
     }
     [GrowingEventGenerator generateConversionAttributesEvent:variables];
+}
+
+- (void)setConversionVariablesWithAttributesBuilder:(GrowingAttributesBuilder *)attributesBuilder {
+    NSDictionary *attributes = attributesBuilder.build;
+    [self setConversionVariables:attributes];
 }
 
 - (void)setLoginUserId:(NSString *)userId {

--- a/Podfile
+++ b/Podfile
@@ -17,6 +17,7 @@ target 'Example' do
 #  pod 'GrowingAnalytics/Advertising'
 #  pod 'GrowingAnalytics/DISABLE_IDFA', :path => './' #禁用idfa
   pod 'SDCycleScrollView', '~> 1.75'
+  pod 'GrowingToolsKit'
 end
 
 target 'GrowingAnalyticsTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
-  - GrowingAnalytics-cdp/Autotracker (3.3.5-beta):
-    - GrowingAnalytics-cdp/TrackerCore (= 3.3.5-beta)
-    - GrowingAnalytics/AutotrackerCore (= 3.3.5-beta)
-    - GrowingAnalytics/Compression (= 3.3.5-beta)
-    - GrowingAnalytics/Database (= 3.3.5-beta)
-    - GrowingAnalytics/Encryption (= 3.3.5-beta)
-    - GrowingAnalytics/Hybrid (= 3.3.5-beta)
-    - GrowingAnalytics/MobileDebugger (= 3.3.5-beta)
-    - GrowingAnalytics/Network (= 3.3.5-beta)
-    - GrowingAnalytics/WebCircle (= 3.3.5-beta)
-  - GrowingAnalytics-cdp/Tracker (3.3.5-beta):
-    - GrowingAnalytics-cdp/TrackerCore (= 3.3.5-beta)
-    - GrowingAnalytics/Compression (= 3.3.5-beta)
-    - GrowingAnalytics/Database (= 3.3.5-beta)
-    - GrowingAnalytics/Encryption (= 3.3.5-beta)
-    - GrowingAnalytics/MobileDebugger (= 3.3.5-beta)
-    - GrowingAnalytics/Network (= 3.3.5-beta)
-  - GrowingAnalytics-cdp/TrackerCore (3.3.5-beta):
-    - GrowingAnalytics/TrackerCore (= 3.3.5-beta)
-  - GrowingAnalytics/Autotracker (3.3.5-beta):
+  - GrowingAnalytics-cdp/Autotracker (3.3.5):
+    - GrowingAnalytics-cdp/TrackerCore (= 3.3.5)
+    - GrowingAnalytics/AutotrackerCore (= 3.3.5)
+    - GrowingAnalytics/Compression (= 3.3.5)
+    - GrowingAnalytics/Database (= 3.3.5)
+    - GrowingAnalytics/Encryption (= 3.3.5)
+    - GrowingAnalytics/Hybrid (= 3.3.5)
+    - GrowingAnalytics/MobileDebugger (= 3.3.5)
+    - GrowingAnalytics/Network (= 3.3.5)
+    - GrowingAnalytics/WebCircle (= 3.3.5)
+  - GrowingAnalytics-cdp/Tracker (3.3.5):
+    - GrowingAnalytics-cdp/TrackerCore (= 3.3.5)
+    - GrowingAnalytics/Compression (= 3.3.5)
+    - GrowingAnalytics/Database (= 3.3.5)
+    - GrowingAnalytics/Encryption (= 3.3.5)
+    - GrowingAnalytics/MobileDebugger (= 3.3.5)
+    - GrowingAnalytics/Network (= 3.3.5)
+  - GrowingAnalytics-cdp/TrackerCore (3.3.5):
+    - GrowingAnalytics/TrackerCore (= 3.3.5)
+  - GrowingAnalytics/Autotracker (3.3.5):
     - GrowingAnalytics/AutotrackerCore
     - GrowingAnalytics/Compression
     - GrowingAnalytics/Database
@@ -27,43 +27,62 @@ PODS:
     - GrowingAnalytics/MobileDebugger
     - GrowingAnalytics/Network
     - GrowingAnalytics/WebCircle
-  - GrowingAnalytics/AutotrackerCore (3.3.5-beta):
+  - GrowingAnalytics/AutotrackerCore (3.3.5):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Compression (3.3.5-beta):
+  - GrowingAnalytics/Compression (3.3.5):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Database (3.3.5-beta):
+  - GrowingAnalytics/Database (3.3.5):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Encryption (3.3.5-beta):
+  - GrowingAnalytics/Encryption (3.3.5):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Hybrid (3.3.5-beta):
+  - GrowingAnalytics/Hybrid (3.3.5):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/MobileDebugger (3.3.5-beta):
+  - GrowingAnalytics/MobileDebugger (3.3.5):
     - GrowingAnalytics/TrackerCore
     - GrowingAnalytics/WebSocket
-  - GrowingAnalytics/Network (3.3.5-beta):
+  - GrowingAnalytics/Network (3.3.5):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Protobuf (3.3.5-beta):
+  - GrowingAnalytics/Protobuf (3.3.5):
     - GrowingAnalytics/Database
-    - GrowingAnalytics/Protobuf/Proto (= 3.3.5-beta)
+    - GrowingAnalytics/Protobuf/Proto (= 3.3.5)
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Protobuf/Proto (3.3.5-beta):
+  - GrowingAnalytics/Protobuf/Proto (3.3.5):
     - GrowingAnalytics/Database
     - GrowingAnalytics/TrackerCore
     - Protobuf
-  - GrowingAnalytics/Tracker (3.3.5-beta):
+  - GrowingAnalytics/Tracker (3.3.5):
     - GrowingAnalytics/Compression
     - GrowingAnalytics/Database
     - GrowingAnalytics/Encryption
     - GrowingAnalytics/MobileDebugger
     - GrowingAnalytics/Network
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/TrackerCore (3.3.5-beta)
-  - GrowingAnalytics/WebCircle (3.3.5-beta):
+  - GrowingAnalytics/TrackerCore (3.3.5)
+  - GrowingAnalytics/WebCircle (3.3.5):
     - GrowingAnalytics/AutotrackerCore
     - GrowingAnalytics/Hybrid
     - GrowingAnalytics/WebSocket
-  - GrowingAnalytics/WebSocket (3.3.5-beta):
+  - GrowingAnalytics/WebSocket (3.3.5):
     - GrowingAnalytics/TrackerCore
+  - GrowingToolsKit (1.0.5):
+    - GrowingToolsKit/Default (= 1.0.5)
+  - GrowingToolsKit/Core (1.0.5):
+    - GrowingToolsKit/Res
+  - GrowingToolsKit/Default (1.0.5):
+    - GrowingToolsKit/Core
+    - GrowingToolsKit/EventsList
+    - GrowingToolsKit/NetFlow
+    - GrowingToolsKit/SDKInfo
+    - GrowingToolsKit/XPathTrack
+  - GrowingToolsKit/EventsList (1.0.5):
+    - GrowingToolsKit/Core
+  - GrowingToolsKit/NetFlow (1.0.5):
+    - GrowingToolsKit/Core
+  - GrowingToolsKit/Res (1.0.5)
+  - GrowingToolsKit/SDKInfo (1.0.5):
+    - GrowingToolsKit/Core
+  - GrowingToolsKit/XPathTrack (1.0.5):
+    - GrowingToolsKit/Core
   - KIF (3.8.6):
     - KIF/Core (= 3.8.6)
   - KIF/Core (3.8.6)
@@ -80,11 +99,13 @@ DEPENDENCIES:
   - GrowingAnalytics/Autotracker (from `./`)
   - GrowingAnalytics/Protobuf (from `./`)
   - GrowingAnalytics/Tracker (from `./`)
+  - GrowingToolsKit
   - KIF
   - SDCycleScrollView (~> 1.75)
 
 SPEC REPOS:
   trunk:
+    - GrowingToolsKit
     - KIF
     - Protobuf
     - SDCycleScrollView
@@ -97,13 +118,14 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: f35717ba5481c7e0f579ab821959d0ff4bb20408
-  GrowingAnalytics-cdp: 779bf481efdba316356c0f5e89c994f473cca604
+  GrowingAnalytics: 8963b86c8a54705bad946b1a479090802fe696db
+  GrowingAnalytics-cdp: d9cb1bdd747d3fba719d4b9864128d9eb173ca67
+  GrowingToolsKit: fd088ef90c60a7cb6166530dc0eb630e966b4eab
   KIF: e2e1bab222b6c9523a0a88caab31f8524fe82404
   Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
   SDCycleScrollView: a0d74c3384caa72bdfc81470bdbc8c14b3e1fbcf
   SDWebImage: 0905f1b7760fc8ac4198cae0036600d67478751e
 
-PODFILE CHECKSUM: c1fa72efd4f1c5e6a3b6f1ee91650b289290795e
+PODFILE CHECKSUM: 94ebf3e527f5c5519b1781c6b64264ba3aef4aa0
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
## PR 内容

- feat: LOGIN_USER_ATTRIBUTES 事件属性支持 NSArray<ObjectType\>
  **其中 Key 必须是 NSString 类型，可为空字符串**
  **当事件属性为 `NSArray<NSNull *>` 类型时，NSNull 转为空字符串**
  示例代码如下：
  ```Objective-C
  GrowingAttributesBuilder *builder = GrowingAttributesBuilder.new;
  [builder setString:@"value" forKey:@"key"];
  [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@"key2"];
  [builder setArray:@[@1, @2, @3] forKey:@"key3"];
  [builder setArray:@[@[@"1"], @[@"2"], @[@"3"]] forKey:@"key4"];
  [builder setArray:@[@{@"value":@"key"}, @{@"value":@"key"}, @{@"value":@"key"}] forKey:@"key5"];
  [builder setArray:@[NSObject.new, NSObject.new, NSObject.new] forKey:@"key6"];
  [builder setArray:@[NSNull.new, NSNull.new, NSNull.new] forKey:@"key7"];
  [builder setArray:@[@"value1", @"value2", @"value3"] forKey:@""];
  [[GrowingAutotracker sharedInstance] setLoginUserAttributesWithAttributesBuilder:builder];
  ```
- test: LOGIN_USER_ATTRIBUTES 事件属性支持 NSArray<ObjectType\> 补充测试用例
- test: Example 集成 GrowingToolsKit 以便调试

## 测试步骤

- 如示例代码，测试 LOGIN_USER_ATTRIBUTES 事件属性添加 Array 上报是否正常
- 测试边界情况（类型不符、参数为空等，见单测）下，接口调用不报错
- 单元测试通过

## 影响范围

- LOGIN_USER_ATTRIBUTES 事件属性上报

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

- 见 https://github.com/growingio/growingio-sdk-ios-autotracker/pull/197

