### PR TITLE
feat: GrowingEventInterceptor 增加 EventDidWrite 回调，以便新增事件排序

### DIFF
--- a/GrowingTrackerCore/Event/GrowingEventManager.h
+++ b/GrowingTrackerCore/Event/GrowingEventManager.h
@@ -46,6 +46,10 @@
 /// @param event 当前事件
 - (void)growingEventManagerEventDidBuild:(GrowingBaseEvent *_Nullable)event;
 
+/// 事件入库完毕
+/// @param event 当前事件
+- (void)growingEventManagerEventDidWrite:(GrowingBaseEvent *_Nullable)event;
+
 /// 自定义event发送请求
 /// @param channel 事件发送通道
 - (id<GrowingRequestProtocol> _Nullable)growingEventManagerRequestWithChannel:(GrowingEventChannel *_Nullable)channel;

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -180,7 +180,14 @@ static GrowingEventManager *sharedInstance = nil;
                 [obj growingEventManagerEventDidBuild:event];
             }
         }
+        
         [self writeToDatabaseWithEvent:event];
+        
+        for (NSObject<GrowingEventInterceptor> *obj in self.allInterceptor) {
+            if ([obj respondsToSelector:@selector(growingEventManagerEventDidWrite:)]) {
+                [obj growingEventManagerEventDidWrite:event];
+            }
+        }
     };
     [GrowingDispatchManager dispatchInGrowingThread:block];
 }


### PR DESCRIPTION
## PR 内容

- feat: GrowingEventInterceptor 增加 EventDidWrite 回调，以便新增事件排序

## 测试步骤

- CI 通过

## 影响范围

拦截器新增事件的先后入库、发送顺序

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

如果在 EventDidBuild 进行拦截新增事件，被拦截的事件尚未入库，将导致新增的事件入库早于被拦截的事件，虽然 globalSequenceId / eventSequenceId 的顺序正确，但发送时新增的事件也会早于被拦截的事件。

