### PR TITLE
fix: 避免因 delegate 对象重写 class 方法导致 swizzle 失效

### DIFF
--- a/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/UICollectionViewAutotrackTest.m
+++ b/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/UICollectionViewAutotrackTest.m
@@ -73,7 +73,13 @@
 
 @end
 
+@interface AutotrackUICollectionView_Delegate_XCTest : NSObject <UICollectionViewDelegate>
+
+@end
+
 @interface UICollectionViewAutotrackTest : XCTestCase <UICollectionViewDelegate>
+
+@property (nonatomic, strong) AutotrackUICollectionView_Delegate_XCTest *delegate;
 
 @end
 
@@ -105,10 +111,23 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
 }
 
-- (void)testUICollectionViewAutotrack {
+- (void)test01UICollectionViewAutotrack {
     AutotrackUICollectionView_XCTest *collectionView = [[AutotrackUICollectionView_XCTest alloc] initWithFrame:CGRectMake(0, 0, 100, 100)
                                                                                           collectionViewLayout:UICollectionViewLayout.new];
     collectionView.delegate = self;
+    
+    [collectionView.delegate collectionView:collectionView
+                   didSelectItemAtIndexPath:[NSIndexPath indexPathWithIndex:0]];
+    
+    NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeViewClick];
+    XCTAssertEqual(events.count, 1);
+}
+
+- (void)test02UICollectionViewRealDelegate {
+    AutotrackUICollectionView_XCTest *collectionView = [[AutotrackUICollectionView_XCTest alloc] initWithFrame:CGRectMake(0, 0, 100, 100)
+                                                                                          collectionViewLayout:UICollectionViewLayout.new];
+    self.delegate = [AutotrackUICollectionView_Delegate_XCTest new];
+    collectionView.delegate = self.delegate;
     
     [collectionView.delegate collectionView:collectionView
                    didSelectItemAtIndexPath:[NSIndexPath indexPathWithIndex:0]];
@@ -126,3 +145,17 @@
 @end
 
 #pragma clang diagnostic pop
+
+@implementation AutotrackUICollectionView_Delegate_XCTest
+
+#pragma mark - UICollectionView Delegate
+
+- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+    
+}
+
+- (Class)class {
+    return UICollectionViewController.class;
+}
+
+@end

--- a/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/UITableViewAutotrackTest.m
+++ b/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/UITableViewAutotrackTest.m
@@ -73,7 +73,13 @@
 
 @end
 
+@interface AutotrackUITableView_Delegate_XCTest : NSObject <UITableViewDelegate>
+
+@end
+
 @interface UITableViewAutotrackTest : XCTestCase <UITableViewDelegate>
+
+@property (nonatomic, strong) AutotrackUITableView_Delegate_XCTest *delegate;
 
 @end
 
@@ -105,9 +111,20 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
 }
 
-- (void)testUITableViewAutotrack {
+- (void)test01UITableViewAutotrack {
     AutotrackUITableView_XCTest *tableView = [[AutotrackUITableView_XCTest alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
     tableView.delegate = self;
+    
+    [tableView.delegate tableView:tableView didSelectRowAtIndexPath:[NSIndexPath indexPathWithIndex:0]];
+    
+    NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeViewClick];
+    XCTAssertEqual(events.count, 1);
+}
+
+- (void)test02UITableViewRealDelegate {
+    AutotrackUITableView_XCTest *tableView = [[AutotrackUITableView_XCTest alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+    self.delegate = [AutotrackUITableView_Delegate_XCTest new];
+    tableView.delegate = self.delegate;
     
     [tableView.delegate tableView:tableView didSelectRowAtIndexPath:[NSIndexPath indexPathWithIndex:0]];
     
@@ -124,3 +141,17 @@
 @end
 
 #pragma clang diagnostic pop
+
+@implementation AutotrackUITableView_Delegate_XCTest
+
+#pragma mark - UITableView Delegate
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
+    
+}
+
+- (Class)class {
+    return UITableViewController.class;
+}
+
+@end

--- a/GrowingTrackerCore/Swizzle/GrowingSwizzler.m
+++ b/GrowingTrackerCore/Swizzle/GrowingSwizzler.m
@@ -88,7 +88,7 @@
 static NSMapTable *growingSwizzles;
 
 static void growing_swizzledMethod_2(id self, SEL _cmd) {
-    Method aMethod = class_getInstanceMethod([self class], _cmd);
+    Method aMethod = class_getInstanceMethod(object_getClass(self), _cmd);
     GrowingSwizzleEntity *swizzle = (GrowingSwizzleEntity *)[growingSwizzles objectForKey:GROWING_MAPTABLE_ID(aMethod)];
     if (swizzle) {
         ((void(*)(id, SEL))swizzle.originalMethod)(self, _cmd);
@@ -102,7 +102,7 @@ static void growing_swizzledMethod_2(id self, SEL _cmd) {
 }
 
 static void growing_swizzledMethod_3(id self, SEL _cmd, id arg) {
-    Method aMethod = class_getInstanceMethod([self class], _cmd);
+    Method aMethod = class_getInstanceMethod(object_getClass(self), _cmd);
     GrowingSwizzleEntity *swizzle = (GrowingSwizzleEntity *)[growingSwizzles objectForKey:GROWING_MAPTABLE_ID(aMethod)];
     if (swizzle) {
         ((void(*)(id, SEL, id))swizzle.originalMethod)(self, _cmd, arg);
@@ -116,7 +116,7 @@ static void growing_swizzledMethod_3(id self, SEL _cmd, id arg) {
 }
 
 static void growing_swizzledMethod_4(id self, SEL _cmd, id arg, id arg2) {
-    Method aMethod = class_getInstanceMethod([self class], _cmd);
+    Method aMethod = class_getInstanceMethod(object_getClass(self), _cmd);
     GrowingSwizzleEntity *swizzle = (GrowingSwizzleEntity *)[growingSwizzles objectForKey:(__bridge id)((void *)aMethod)];
     if (swizzle) {
         ((void(*)(id, SEL, id, id))swizzle.originalMethod)(self, _cmd, arg, arg2);
@@ -130,7 +130,7 @@ static void growing_swizzledMethod_4(id self, SEL _cmd, id arg, id arg2) {
 }
 
 static void growing_swizzledMethod_5(id self, SEL _cmd, id arg, id arg2, id arg3) {
-    Method aMethod = class_getInstanceMethod([self class], _cmd);
+    Method aMethod = class_getInstanceMethod(object_getClass(self), _cmd);
     GrowingSwizzleEntity *swizzle = (GrowingSwizzleEntity *)[growingSwizzles objectForKey:(__bridge id)((void *)aMethod)];
     if (swizzle) {
         ((void(*)(id, SEL, id, id, id))swizzle.originalMethod)(self, _cmd, arg, arg2, arg3);


### PR DESCRIPTION
## PR 内容

- fix: 避免因 delegate 对象重写 class 方法导致 swizzle 失效
- test: 补充单元测试 - UITableView / UICollectionView setDelegate 对象重写 class 方法

## 测试步骤

- CI 通过

## 影响范围

- UITableView / UICollectionView 无埋点点击事件

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

- 与火山引擎的 UITableView / UICollectionView setDelegate Hook 起冲突

