### PR TITLE
fix: 避免因 delegate 对象重写 class 方法导致 swizzle 失效

### DIFF
--- a/GrowingAutotrackerCore/Autotrack/UICollectionView+GrowingAutotracker.m
+++ b/GrowingAutotrackerCore/Autotrack/UICollectionView+GrowingAutotracker.m
@@ -27,8 +27,8 @@
 
 - (void)growing_setDelegate:(id<UICollectionViewDelegate>)delegate {
     SEL selector = @selector(collectionView:didSelectItemAtIndexPath:);
-    Class class = [GrowingSwizzler realDelegateClassFromSelector:selector proxy:delegate];
-    
+    id<UICollectionViewDelegate> realDelegate = [GrowingSwizzler realDelegate:delegate toSelector:selector];
+    Class class = realDelegate.class;
     if ([GrowingSwizzler realDelegateClass:class respondsToSelector:selector]) {
         
         void (^didSelectItemBlock)(id, SEL, id, id) = ^(id view, SEL command, UICollectionView *collectionView, NSIndexPath *indexPath) {

--- a/GrowingAutotrackerCore/Autotrack/UITableView+GrowingAutotracker.m
+++ b/GrowingAutotrackerCore/Autotrack/UITableView+GrowingAutotracker.m
@@ -27,8 +27,8 @@
 
 - (void)growing_setDelegate:(id<UITableViewDelegate>)delegate {
     SEL selector = @selector(tableView:didSelectRowAtIndexPath:);
-    Class class = [GrowingSwizzler realDelegateClassFromSelector:selector proxy:delegate];
-    
+    id<UITableViewDelegate> realDelegate = [GrowingSwizzler realDelegate:delegate toSelector:selector];
+    Class class = realDelegate.class;
     if ([GrowingSwizzler realDelegateClass:class respondsToSelector:selector]) {
 
         void (^didSelectBlock)(id, SEL, id, id) = ^(id view, SEL command, UITableView *tableView, NSIndexPath *indexPath) {

--- a/GrowingTrackerCore/Swizzle/GrowingSwizzler.h
+++ b/GrowingTrackerCore/Swizzle/GrowingSwizzler.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GrowingSwizzler : NSObject
 //setDelegate时，返回正确的delegate
-+ (Class)realDelegateClassFromSelector:(SEL)selector proxy:(id)proxy;
++ (id)realDelegate:(id)proxy toSelector:(SEL)selector;
 + (BOOL)realDelegateClass:(Class)cls respondsToSelector:(SEL)sel;
 + (void)growing_swizzleSelector:(SEL)aSelector
                         onClass:(Class)aClass

--- a/GrowingTrackerCore/Swizzle/GrowingSwizzler.m
+++ b/GrowingTrackerCore/Swizzle/GrowingSwizzler.m
@@ -193,7 +193,7 @@ static void (*growing_swizzledMethods[GROWING_MAX_ARGS - GROWING_MIN_ARGS + 1])(
     return isLocal;
 }
 
-+ (Class)realDelegateClassFromSelector:(SEL)selector proxy:(id)proxy {
++ (id)realDelegate:(id)proxy toSelector:(SEL)selector {
     if (!proxy) {
         return nil;
     }
@@ -212,7 +212,8 @@ static void (*growing_swizzledMethods[GROWING_MAX_ARGS - GROWING_MIN_ARGS + 1])(
         if (!obj) break;
         realDelegate = obj;
     } while (obj);
-    return object_getClass(realDelegate);
+    
+    return realDelegate;
 }
 
 + (BOOL)realDelegateClass:(Class)cls respondsToSelector:(SEL)sel {

--- a/GrowingTrackerCore/Swizzle/GrowingSwizzler.m
+++ b/GrowingTrackerCore/Swizzle/GrowingSwizzler.m
@@ -88,7 +88,7 @@
 static NSMapTable *growingSwizzles;
 
 static void growing_swizzledMethod_2(id self, SEL _cmd) {
-    Method aMethod = class_getInstanceMethod(object_getClass(self), _cmd);
+    Method aMethod = class_getInstanceMethod([self class], _cmd);
     GrowingSwizzleEntity *swizzle = (GrowingSwizzleEntity *)[growingSwizzles objectForKey:GROWING_MAPTABLE_ID(aMethod)];
     if (swizzle) {
         ((void(*)(id, SEL))swizzle.originalMethod)(self, _cmd);
@@ -102,7 +102,7 @@ static void growing_swizzledMethod_2(id self, SEL _cmd) {
 }
 
 static void growing_swizzledMethod_3(id self, SEL _cmd, id arg) {
-    Method aMethod = class_getInstanceMethod(object_getClass(self), _cmd);
+    Method aMethod = class_getInstanceMethod([self class], _cmd);
     GrowingSwizzleEntity *swizzle = (GrowingSwizzleEntity *)[growingSwizzles objectForKey:GROWING_MAPTABLE_ID(aMethod)];
     if (swizzle) {
         ((void(*)(id, SEL, id))swizzle.originalMethod)(self, _cmd, arg);
@@ -116,7 +116,7 @@ static void growing_swizzledMethod_3(id self, SEL _cmd, id arg) {
 }
 
 static void growing_swizzledMethod_4(id self, SEL _cmd, id arg, id arg2) {
-    Method aMethod = class_getInstanceMethod(object_getClass(self), _cmd);
+    Method aMethod = class_getInstanceMethod([self class], _cmd);
     GrowingSwizzleEntity *swizzle = (GrowingSwizzleEntity *)[growingSwizzles objectForKey:(__bridge id)((void *)aMethod)];
     if (swizzle) {
         ((void(*)(id, SEL, id, id))swizzle.originalMethod)(self, _cmd, arg, arg2);
@@ -130,7 +130,7 @@ static void growing_swizzledMethod_4(id self, SEL _cmd, id arg, id arg2) {
 }
 
 static void growing_swizzledMethod_5(id self, SEL _cmd, id arg, id arg2, id arg3) {
-    Method aMethod = class_getInstanceMethod(object_getClass(self), _cmd);
+    Method aMethod = class_getInstanceMethod([self class], _cmd);
     GrowingSwizzleEntity *swizzle = (GrowingSwizzleEntity *)[growingSwizzles objectForKey:(__bridge id)((void *)aMethod)];
     if (swizzle) {
         ((void(*)(id, SEL, id, id, id))swizzle.originalMethod)(self, _cmd, arg, arg2, arg3);


### PR DESCRIPTION
## PR 内容

- revert: Commit https://github.com/growingio/growingio-sdk-ios-autotracker/commit/06d88d3c0e940c6a420393d36c77e0001d9d23bb
  - 场景 1：「SDK 初始化期间替换 UITableView / UICollectionView setDelegate: 方法时与 delegate 对应代理方法实际调用时，delegate 对象都为动态子类实例 (重写了 class)」 (比如同时集成了火山引擎)
  - 场景 2：「SDK 初始化期间替换 UITableView / UICollectionView setDelegate: 方法时，delegate 对象为 originClass 实例；delegate 对应代理方法实际调用时，delegate 对象为动态子类实例 (重写了 class)」 (比如同时集成了神策)
  - 此 Commit 比较片面，只解决了场景 1；但是如场景 2 这种情况下，前后都用 object_getClass(id obj) 显然是不正确的
- fix: 避免因 delegate 对象重写 class 方法导致 swizzle 失效
- test: 补充单元测试 - UITableView / UICollectionView setDelegate 对象为动态子类，且重写了 class 方法

## 测试步骤

- CI 通过

## 影响范围

- UITableView / UICollectionView 无埋点点击事件

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

- https://github.com/growingio/growingio-sdk-ios-autotracker/pull/87
- https://github.com/growingio/growingio-sdk-ios-autotracker/pull/105
- https://github.com/growingio/growingio-sdk-ios-autotracker/pull/218

