### PR TITLE
fix: 系统库文件如 sqlite3.h 应使用尖括号导入，而不是引号

### DIFF
--- a/GrowingAnalytics-cdp.podspec
+++ b/GrowingAnalytics-cdp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics-cdp'
-  s.version          = '3.4.2'
+  s.version          = '3.4.2-hotfix.1'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics-cdp基于GrowingAnalytics，同样具备自动采集基本的用户行为事件，比如访问和行为数据等。

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.4.2'
+  s.version          = '3.4.2-hotfix.1'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -39,7 +39,7 @@
 #import "GrowingTrackerCore/Public/GrowingServiceManager.h"
 #import "GrowingTrackerCore/Event/GrowingEventManager.h"
 
-NSString *const GrowingTrackerVersionName = @"3.4.2";
+NSString *const GrowingTrackerVersionName = @"3.4.2-hotfix.1";
 const int GrowingTrackerVersionCode = 30402;
 
 @interface GrowingRealTracker ()

--- a/Services/Database/FMDB/GrowingFMDatabase.h
+++ b/Services/Database/FMDB/GrowingFMDatabase.h
@@ -37,7 +37,7 @@
 //  limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
+#import <sqlite3.h>
 #import "Services/Database/FMDB/GrowingFMResultSet.h"
 #import "Services/Database/FMDB/GrowingFMDatabasePool.h"
 

--- a/Services/Database/FMDB/GrowingFMDatabase.m
+++ b/Services/Database/FMDB/GrowingFMDatabase.m
@@ -37,7 +37,7 @@
 //  limitations under the License.
 
 #import "Services/Database/FMDB/GrowingFMDatabase.h"
-#import "unistd.h"
+#import <unistd.h>
 #import <objc/runtime.h>
 
 @interface GrowingFMDatabase ()

--- a/Services/Database/FMDB/GrowingFMDatabaseAdditions.m
+++ b/Services/Database/FMDB/GrowingFMDatabaseAdditions.m
@@ -38,7 +38,7 @@
 
 #import "Services/Database/FMDB/GrowingFMDatabase.h"
 #import "Services/Database/FMDB/GrowingFMDatabaseAdditions.h"
-#import "TargetConditionals.h"
+#import <TargetConditionals.h>
 
 @interface GrowingFMDatabase (PrivateStuff)
 - (GrowingFMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args;

--- a/Services/Database/FMDB/GrowingFMDatabasePool.h
+++ b/Services/Database/FMDB/GrowingFMDatabasePool.h
@@ -37,7 +37,7 @@
 //  limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
+#import <sqlite3.h>
 
 @class GrowingFMDatabase;
 

--- a/Services/Database/FMDB/GrowingFMDatabaseQueue.h
+++ b/Services/Database/FMDB/GrowingFMDatabaseQueue.h
@@ -37,7 +37,7 @@
 //  limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
+#import <sqlite3.h>
 
 @class GrowingFMDatabase;
 

--- a/Services/Database/FMDB/GrowingFMResultSet.h
+++ b/Services/Database/FMDB/GrowingFMResultSet.h
@@ -37,7 +37,7 @@
 //  limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
+#import <sqlite3.h>
 
 #ifndef __has_feature      // Optional.
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.

--- a/Services/Database/FMDB/GrowingFMResultSet.m
+++ b/Services/Database/FMDB/GrowingFMResultSet.m
@@ -38,7 +38,7 @@
 
 #import "Services/Database/FMDB/GrowingFMResultSet.h"
 #import "Services/Database/FMDB/GrowingFMDatabase.h"
-#import "unistd.h"
+#import <unistd.h>
 
 @interface GrowingFMDatabase ()
 - (void)resultSetDidClose:(GrowingFMResultSet *)resultSet;


### PR DESCRIPTION
## PR 内容

- fix: 系统库文件如 sqlite3.h 应使用尖括号导入，而不是引号

## 测试步骤

- CI 通过
- 同时集成 SQLCipher，能够正常编译运行，`pod 'SQLCipher'`

## 影响范围

- 同时集成其他第三方库 (比如 SQLCipher) 且其内部重写了 sqlite3.h 作为 Public Header 时，应该正常编译运行

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

- https://stackoverflow.com/questions/50361079/sqlite3-h-file-not-found-after-pod-firebasemessaging-update

