### PR TITLE
fix: HZSSI-2001 parentView 不可见时，圈选遍历不应该包含 subViews

### DIFF
--- a/Modules/WebCircle/GrowingWebCircle.m
+++ b/Modules/WebCircle/GrowingWebCircle.m
@@ -230,15 +230,19 @@ GrowingMod(GrowingWebCircle)
         return;
     }
     UIView *node = viewNode.view;
-    if ([node growingNodeUserInteraction] || [node isKindOfClass:NSClassFromString(@"WKWebView")]) {
-        if ([node growingNodeDonotTrack] || [node growingNodeDonotCircle]) {
-            GIOLogDebug(@"圈选过滤节点:%@,DontTrack:%d,DontCircle:%d", [node class], [node growingNodeDonotTrack],
-                        [node growingNodeDonotCircle]);
-        } else {
+    if ([node growingNodeDonotCircle]) {
+        GIOLogDebug(@"过滤节点：%@ 因不可见，无法圈选", [node class]);
+        return;
+    }
+    
+    if ([node growingNodeDonotTrack]) {
+        GIOLogDebug(@"过滤节点：%@ 已忽略，无需圈选", [node class]);
+    } else {
+        if ([node growingNodeUserInteraction] || [node isKindOfClass:NSClassFromString(@"WKWebView")]) {
             NSMutableDictionary *dict = [self dictFromNode:viewNode];
-            if ([viewNode.view isKindOfClass:NSClassFromString(@"WKWebView")]) {
+            if ([node isKindOfClass:NSClassFromString(@"WKWebView")]) {
                 [[GrowingHybridBridgeProvider sharedInstance]
-                    getDomTreeForWebView:(WKWebView *)viewNode.view
+                    getDomTreeForWebView:(WKWebView *)node
                        completionHandler:^(NSDictionary *_Nullable domTee, NSError *_Nullable error) {
                            if (domTee.count > 0) {
                                [dict setValue:domTee forKey:@"webView"];


### PR DESCRIPTION
## PR 内容

- fix: parentView 不可见时，圈选遍历上报的 elements 不应该包含其 subViews
  圈选时，如果不可见的控件也包含在内，则会导致 z-Index 较低的可圈选控件被遮挡而无法圈选

## 测试步骤

1. 在 Demo 中任意 ViewController viewDidLoad 方法中添加如下代码：
```Objective-C
UIView *view = [[UIView alloc] initWithFrame:self.view.bounds];
UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
button.frame = view.bounds;
[button addTarget:self action:@selector(description) forControlEvents:UIControlEventTouchUpInside];
[view addSubview:button];
[self.view addSubview:view];

// parentView 不可见，则圈选上报 elements 不应该包含 parentView 内部的 subViews
view.hidden = YES;
```
2. 进行圈选验证是否正常

## 影响范围

- 无埋点圈选

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

无

