### PR TITLE
fix: 修复延迟初始化下 PAGE 漏发、page.path 不准确等一系列问题

### DIFF
--- a/GrowingAutotrackerCore/Page/GrowingPageManager.m
+++ b/GrowingAutotrackerCore/Page/GrowingPageManager.m
@@ -78,13 +78,7 @@
 - (void)createdViewControllerPage:(UIViewController *)viewController {
     GrowingPageGroup *page = [viewController growingPageHelper_getPageObject];
     if (page == nil) {
-        page = [GrowingPageGroup pageWithCarrier:viewController];
-        page.parent = [self findParentPage:viewController];
-        if (page.parent != nil) {
-            [page.parent addChildrenPage:page];
-        }
-        [self addPageAlias:page];
-        [viewController growingPageHelper_setPageObject:page];
+        page = [self createdPage:viewController];
     } else {
         [page refreshShowTimestamp];
     }
@@ -140,6 +134,17 @@
     }
 }
 
+- (GrowingPageGroup *)createdPage:(UIViewController *)viewController {
+    GrowingPageGroup *page = [GrowingPageGroup pageWithCarrier:viewController];
+    page.parent = [self findParentPage:viewController];
+    if (page.parent != nil) {
+        [page.parent addChildrenPage:page];
+    }
+    [self addPageAlias:page];
+    [viewController growingPageHelper_setPageObject:page];
+    return page;
+}
+
 - (GrowingPageGroup *)findParentPage:(UIViewController *)carrier {
     UIViewController *parentVC = nil;
 
@@ -155,8 +160,7 @@
     } else {
         GrowingPageGroup *page = [parentVC growingPageHelper_getPageObject];
         if (page == nil) {
-            [self.ignoredPrivateControllers addObject:NSStringFromClass(carrier.class)];
-            GIOLogError(@"UIViewController: %@ associated page object is nil", carrier);
+            page = [self createdPage:parentVC];
         }
         return page;
     }

--- a/GrowingAutotrackerCore/Page/GrowingPageManager.m
+++ b/GrowingAutotrackerCore/Page/GrowingPageManager.m
@@ -261,6 +261,9 @@
             current = (UIViewController*)current.growingNodeParent;
         } else {
             page = [current growingPageHelper_getPageObject];
+            if (page == nil) {
+                page = [self createdPage:current];
+            }
             if (page.isIgnored) {
                 current = (UIViewController*)current.growingNodeParent;
             } else {


### PR DESCRIPTION
## PR 内容

- fix: 修复延迟初始化下 PAGE 漏发、page.path 不准确
 #232 
- fix: 修复延迟初始化下 VIEW_CLICK、VIEW_CHANGE 事件参数异常，圈选显示截图异常
 #234 



## 测试步骤

在 AppDelegate 以下代码中初始化 SDK 进行测试 PAGE 事件的发送：
```objc
- (void)applicationDidBecomeActive:(UIApplication *)application {
    NSLog(@"Application - applicationDidBecomeActive");

    if (@available(iOS 14, *)) {
        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
            dispatch_async(dispatch_get_main_queue(), ^{
                // 初始化SDK
                // ...
            });
        }];
    } else {
        // 初始化SDK
        // ...
    }
}
```

## 影响范围

- PAGE 事件正常发送
- PAGE 事件中 path 字段值
- 未创建 GrowingPage 对象的页面 VIEW_CLICK / VIEW_CHANGE 事件中 path、pageShowTimestamp 字段值
- 圈选截图展示正常
- 在平台上使用错误 path 定义的页面需要重新定义

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息

无

