### PR TITLE
fix: app 切后台超过 30s，其唤醒事件 SessionId 未刷新

### DIFF
--- a/Example/Example/AppDelegate.m
+++ b/Example/Example/AppDelegate.m
@@ -47,7 +47,7 @@
     
 #if defined(SDKADVERTMODULE)
     configuration.ASAEnabled = YES;
-    configuration.deepLinkHost = [NSURL URLWithString:@"https://datayi.cn"];
+    configuration.deepLinkHost = @"https://datayi.cn";
     configuration.deepLinkCallback = ^(NSDictionary * _Nullable params, NSTimeInterval processTime, NSError * _Nullable error) {
         if (error) {
             NSLog(@"error = %@", error);

--- a/GrowingTrackerCore/Manager/GrowingSession.h
+++ b/GrowingTrackerCore/Manager/GrowingSession.h
@@ -26,6 +26,12 @@
 
 @end
 
+typedef NS_ENUM(NSInteger, GrowingSessionState) {
+    GrowingSessionStateActive,
+    GrowingSessionStateInactive,
+    GrowingSessionStateBackground
+};
+
 @interface GrowingSession : NSObject
 
 @property (nonatomic, assign, readonly, getter=isSentVisitAfterRefreshSessionId) BOOL sentVisitAfterRefreshSessionId;
@@ -34,6 +40,7 @@
 @property (nonatomic, copy, readonly) NSString *loginUserKey;
 @property (nonatomic, assign, readonly) double latitude;
 @property (nonatomic, assign, readonly) double longitude;
+@property (nonatomic, assign, readonly) GrowingSessionState state;
 
 + (void)startSession;
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,70 +1,70 @@
 PODS:
   - Bugly (2.5.93)
-  - GrowingAnalytics-cdp/Autotracker (3.4.6):
-    - GrowingAnalytics-cdp/TrackerCore (= 3.4.6)
-    - GrowingAnalytics/AutotrackerCore (= 3.4.6)
-    - GrowingAnalytics/DefaultServices (= 3.4.6)
-    - GrowingAnalytics/Hybrid (= 3.4.6)
-    - GrowingAnalytics/MobileDebugger (= 3.4.6)
-    - GrowingAnalytics/WebCircle (= 3.4.6)
-  - GrowingAnalytics-cdp/Tracker (3.4.6):
-    - GrowingAnalytics-cdp/TrackerCore (= 3.4.6)
-    - GrowingAnalytics/DefaultServices (= 3.4.6)
-    - GrowingAnalytics/MobileDebugger (= 3.4.6)
-  - GrowingAnalytics-cdp/TrackerCore (3.4.6):
-    - GrowingAnalytics/TrackerCore (= 3.4.6)
-  - GrowingAnalytics/Advert (3.4.6):
+  - GrowingAnalytics-cdp/Autotracker (3.4.7):
+    - GrowingAnalytics-cdp/TrackerCore (= 3.4.7)
+    - GrowingAnalytics/AutotrackerCore (= 3.4.7)
+    - GrowingAnalytics/DefaultServices (= 3.4.7)
+    - GrowingAnalytics/Hybrid (= 3.4.7)
+    - GrowingAnalytics/MobileDebugger (= 3.4.7)
+    - GrowingAnalytics/WebCircle (= 3.4.7)
+  - GrowingAnalytics-cdp/Tracker (3.4.7):
+    - GrowingAnalytics-cdp/TrackerCore (= 3.4.7)
+    - GrowingAnalytics/DefaultServices (= 3.4.7)
+    - GrowingAnalytics/MobileDebugger (= 3.4.7)
+  - GrowingAnalytics-cdp/TrackerCore (3.4.7):
+    - GrowingAnalytics/TrackerCore (= 3.4.7)
+  - GrowingAnalytics/Advert (3.4.7):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/APM (3.4.6):
+  - GrowingAnalytics/APM (3.4.7):
     - GrowingAnalytics/TrackerCore
     - GrowingAPM/Core
-  - GrowingAnalytics/Autotracker (3.4.6):
+  - GrowingAnalytics/Autotracker (3.4.7):
     - GrowingAnalytics/AutotrackerCore
     - GrowingAnalytics/DefaultServices
     - GrowingAnalytics/Hybrid
     - GrowingAnalytics/MobileDebugger
     - GrowingAnalytics/WebCircle
-  - GrowingAnalytics/AutotrackerCore (3.4.6):
+  - GrowingAnalytics/AutotrackerCore (3.4.7):
     - GrowingAnalytics/TrackerCore
     - GrowingUtils/AutotrackerCore (= 0.0.4)
-  - GrowingAnalytics/Compression (3.4.6):
+  - GrowingAnalytics/Compression (3.4.7):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Database (3.4.6):
+  - GrowingAnalytics/Database (3.4.7):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/DefaultServices (3.4.6):
+  - GrowingAnalytics/DefaultServices (3.4.7):
     - GrowingAnalytics/Compression
     - GrowingAnalytics/Database
     - GrowingAnalytics/Encryption
     - GrowingAnalytics/Network
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Encryption (3.4.6):
+  - GrowingAnalytics/Encryption (3.4.7):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Hybrid (3.4.6):
+  - GrowingAnalytics/Hybrid (3.4.7):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/MobileDebugger (3.4.6):
+  - GrowingAnalytics/MobileDebugger (3.4.7):
     - GrowingAnalytics/TrackerCore
     - GrowingAnalytics/WebSocket
-  - GrowingAnalytics/Network (3.4.6):
+  - GrowingAnalytics/Network (3.4.7):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Protobuf (3.4.6):
+  - GrowingAnalytics/Protobuf (3.4.7):
     - GrowingAnalytics/Database
-    - GrowingAnalytics/Protobuf/Proto (= 3.4.6)
+    - GrowingAnalytics/Protobuf/Proto (= 3.4.7)
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Protobuf/Proto (3.4.6):
+  - GrowingAnalytics/Protobuf/Proto (3.4.7):
     - GrowingAnalytics/Database
     - GrowingAnalytics/TrackerCore
     - Protobuf
-  - GrowingAnalytics/Tracker (3.4.6):
+  - GrowingAnalytics/Tracker (3.4.7):
     - GrowingAnalytics/DefaultServices
     - GrowingAnalytics/MobileDebugger
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/TrackerCore (3.4.6):
+  - GrowingAnalytics/TrackerCore (3.4.7):
     - GrowingUtils/TrackerCore (= 0.0.4)
-  - GrowingAnalytics/WebCircle (3.4.6):
+  - GrowingAnalytics/WebCircle (3.4.7):
     - GrowingAnalytics/AutotrackerCore
     - GrowingAnalytics/Hybrid
     - GrowingAnalytics/WebSocket
-  - GrowingAnalytics/WebSocket (3.4.6):
+  - GrowingAnalytics/WebSocket (3.4.7):
     - GrowingAnalytics/TrackerCore
   - GrowingAPM (0.0.13):
     - GrowingAPM/Core (= 0.0.13)
@@ -164,8 +164,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Bugly: b8715e6ec4004b7f7fbffab0643ba80545aee3da
-  GrowingAnalytics: 0e048c09d4a2bcad34f987ce597d1cd61d76cd50
-  GrowingAnalytics-cdp: 4ff119d9463d264ad53f1b8e63ca6b05e7ad5c52
+  GrowingAnalytics: 920b35f73590c7161e1d54d6f9b6c0d0e3f4a022
+  GrowingAnalytics-cdp: a8b2fbb1e47485813cabe6fe1dc3fe097bb8cff1
   GrowingAPM: ce25d89b064df78eabfefe807fdecabe92602186
   GrowingToolsKit: 8cbc5cf8a3011ab249c529a786432616c099a618
   GrowingUtils: fd6e7d1a87c57dbda30967bbdcbc14546c68cd22


### PR DESCRIPTION
## PR 内容

如当前 App 位于前台，则直接发送唤醒事件；
如当前 App 处于后台，当回到前台后，先发送 VISIT 事件，再发送唤醒事件
见：https://jira.startdt.net/browse/ANLSPI-3341

## 测试步骤

- CI 通过

## 影响范围

- Advert Module

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

