### PR TITLE
fix: 修复特殊场景下，每当初始化 SDK，ASAFetcher 都会 startFetch (Advert)

### DIFF
--- a/GrowingTrackerCore/FileStorage/GrowingFileStorage.m
+++ b/GrowingTrackerCore/FileStorage/GrowingFileStorage.m
@@ -40,21 +40,13 @@ NSString *const kGrowingDirCommonPrefix = @"com.growingio.";
 }
 
 - (instancetype)initWithName:(NSString *)name {
-    Protocol *proto = NSProtocolFromString(@"GrowingEncryptionService");
-    id <GrowingEncryptionService> impl;
-    if (proto) {
-        impl = [[GrowingServiceManager sharedInstance] createService:proto];
-    }
-    return [self initWithName:name directory:GrowingUserDirectoryLibrary crypto:impl];
+    id <GrowingEncryptionService> service = [[GrowingServiceManager sharedInstance] createService:@protocol(GrowingEncryptionService)];
+    return [self initWithName:name directory:GrowingUserDirectoryLibrary crypto:service];
 }
 
 - (instancetype)initWithName:(NSString *)name directory:(GrowingUserDirectory)directory {
-    Protocol *proto = NSProtocolFromString(@"GrowingEncryptionService");
-    id <GrowingEncryptionService> impl;
-    if (proto) {
-        impl = [[GrowingServiceManager sharedInstance] createService:proto];
-    }
-    return [self initWithName:name directory:directory crypto:impl];
+    id <GrowingEncryptionService> service = [[GrowingServiceManager sharedInstance] createService:@protocol(GrowingEncryptionService)];
+    return [self initWithName:name directory:directory crypto:service];
 }
 
 - (instancetype)initWithName:(NSString *)name directory:(GrowingUserDirectory)directory crypto:(id<GrowingEncryptionService> _Nullable)crypto {

--- a/GrowingTrackerCore/Helpers/Foundation/NSData+GrowingHelper.m
+++ b/GrowingTrackerCore/Helpers/Foundation/NSData+GrowingHelper.m
@@ -33,9 +33,9 @@
 }
 
 - (NSData *)growingHelper_LZ4String {
-    id <GrowingCompressService> compressImpl = [[GrowingServiceManager sharedInstance] createService:NSProtocolFromString(@"GrowingCompressService")];
-    if (compressImpl) {
-        return [compressImpl compressedEventData:self];
+    id <GrowingCompressService> service = [[GrowingServiceManager sharedInstance] createService:@protocol(GrowingCompressService)];
+    if (service) {
+        return [service compressedEventData:self];
     }
     GIOLogDebug(@"NSData -growingHelper_LZ4String compressed error : no compress service support");
     return self;
@@ -141,9 +141,9 @@
 }
 
 - (NSData *)growingHelper_xorEncryptWithHint:(unsigned char)hint {
-    id <GrowingEncryptionService> impl = [[GrowingServiceManager sharedInstance] createService:NSProtocolFromString(@"GrowingEncryptionService")];
-    if (impl) {
-        return [impl encryptEventData:self factor:hint];
+    id <GrowingEncryptionService> service = [[GrowingServiceManager sharedInstance] createService:@protocol(GrowingEncryptionService)];
+    if (service) {
+        return [service encryptEventData:self factor:hint];
     }
     GIOLogDebug(@"NSData -growingHelper_xorEncryptWithHint Encrypt error : no encrypt service support");
     return self;

--- a/Modules/Advert/AppleSearchAds/GrowingAsaFetcher.m
+++ b/Modules/Advert/AppleSearchAds/GrowingAsaFetcher.m
@@ -94,6 +94,16 @@ static pthread_rwlock_t _lock = PTHREAD_RWLOCK_INITIALIZER;
         }
     }
     if (activate == nil) {
+        if ([GrowingAdUtils isActivateWrote]) {
+            // 已产生activate事件且已发送(数据库内无activate事件且isActivateWrote)
+            // 一般发生于：activate事件发送之后，[GrowingAdUtils setActivateSent:YES]执行过程中，文件写入失败
+            GrowingAsaFetcher.status = GrowingAsaFetcherStatusCompleted;
+            [GrowingAdUtils setActivateSent:YES];
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[GrowingEventManager sharedInstance] removeInterceptor:self];
+            });
+        }
         return events;
     }
     


### PR DESCRIPTION
## PR 内容

* fix: 修复特殊场景下，每当初始化 SDK，ASAFetcher 都会 startFetch (Advert)

## 测试步骤

### 复现步骤
1. 注释 setActivateSent 内部代码，模拟特殊场景 (如本地缓存文件写入失败) https://github.com/growingio/growingio-sdk-ios-autotracker/blob/7342a8eeba888760e77f4a0281978d7bb31f3b4d/Modules/Advert/Utils/GrowingAdUtils.m#L186
2. 首次运行启动 App，等待发送激活事件 (此时由于步骤 1，setActivateSent 内代码未执行，所以已发送激活事件的本地标记缓存未存储)
3. 发送成功后，反注释步骤 1 的代码，杀掉 App 再次运行，还是会开启 ASAFetcher 并请求 ASA 数据，此为异常

正常情况下，激活事件已发送，则 ASAFetcher 不再去请求获取，GrowingAsaFetcher.status 直接为 GrowingAsaFetcherStatusCompleted

## 影响范围

- Advert Module

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

