### PR TITLE
fix: priority inversion issue by Xcode14 thread performance checker

### DIFF
--- a/GrowingTrackerCore/Thirdparty/Logger/GrowingLog.m
+++ b/GrowingTrackerCore/Thirdparty/Logger/GrowingLog.m
@@ -63,21 +63,6 @@
 
 #define NSLogDebug(frmt, ...) do{ if(Growing_DEBUG) NSLog((frmt), ##__VA_ARGS__); } while(0)
 
-// Specifies the maximum queue size of the logging thread.
-//
-// Since most logging is asynchronous, its possible for rogue threads to flood the logging queue.
-// That is, to issue an abundance of log statements faster than the logging thread can keep up.
-// Typically such a scenario occurs when log statements are added haphazardly within large loops,
-// but may also be possible if relatively slow loggers are being used.
-//
-// This property caps the queue size at a given number of outstanding log statements.
-// If a thread attempts to issue a log statement when the queue is already maxed out,
-// the issuing thread will block until the queue size drops below the max again.
-
-#ifndef GrowingLOG_MAX_QUEUE_SIZE
-    #define GrowingLOG_MAX_QUEUE_SIZE 1000 // Should not exceed INT32_MAX
-#endif
-
 // The "global logging queue" refers to [GrowingLog loggingQueue].
 // It is the queue that all log statements go through.
 //
@@ -127,10 +112,6 @@ static dispatch_queue_t _loggingQueue;
 // Each logger has it's own associated queue, and a dispatch group is used for synchronization.
 static dispatch_group_t _loggingGroup;
 
-// In order to prevent to queue from growing infinitely large,
-// a maximum size is enforced (GrowingLOG_MAX_QUEUE_SIZE).
-static dispatch_semaphore_t _queueSemaphore;
-
 // Minor optimization for uniprocessor machines
 static NSUInteger _numProcessors;
 
@@ -170,8 +151,6 @@ static NSUInteger _numProcessors;
 
         void *nonNullValue = GlobalLoggingQueueIdentityKey; // Whatever, just not null
         dispatch_queue_set_specific(_loggingQueue, GlobalLoggingQueueIdentityKey, nonNullValue, NULL);
-
-        _queueSemaphore = dispatch_semaphore_create(GrowingLOG_MAX_QUEUE_SIZE);
 
         // Figure out how many processors are available.
         // This may be used later for an optimization on uniprocessor machines.
@@ -354,18 +333,7 @@ static NSUInteger _numProcessors;
     // It should block until log messages A and B have been unqueued.
 
 
-    // We are using a counting semaphore provided by GCD.
-    // The semaphore is initialized with our GrowingLOG_MAX_QUEUE_SIZE value.
-    // Every time we want to queue a log message we decrement this value.
-    // If the resulting value is less than zero,
-    // the semaphore function waits in FIFO order for a signal to occur before returning.
-    //
-    // A dispatch semaphore is an efficient implementation of a traditional counting semaphore.
-    // Dispatch semaphores call down to the kernel only when the calling thread needs to be blocked.
-    // If the calling semaphore does not need to block, no kernel call is made.
-
     dispatch_block_t logBlock = ^{
-        dispatch_semaphore_wait(_queueSemaphore, DISPATCH_TIME_FOREVER);
         // We're now sure we won't overflow the queue.
         // It is time to queue our log message.
         @autoreleasepool {
@@ -885,22 +853,6 @@ static NSUInteger _numProcessors;
             } });
         }
     }
-
-    // If our queue got too big, there may be blocked threads waiting to add log messages to the queue.
-    // Since we've now dequeued an item from the log, we may need to unblock the next thread.
-
-    // We are using a counting semaphore provided by GCD.
-    // The semaphore is initialized with our GrowingLOG_MAX_QUEUE_SIZE value.
-    // When a log message is queued this value is decremented.
-    // When a log message is dequeued this value is incremented.
-    // If the value ever drops below zero,
-    // the queueing thread blocks and waits in FIFO order for us to signal it.
-    //
-    // A dispatch semaphore is an efficient implementation of a traditional counting semaphore.
-    // Dispatch semaphores call down to the kernel only when the calling thread needs to be blocked.
-    // If the calling semaphore does not need to block, no kernel call is made.
-
-    dispatch_semaphore_signal(_queueSemaphore);
 }
 
 - (void)lt_flush {


### PR DESCRIPTION
[dispatch_semaphore_wait](https://developer.apple.com/documentation/dispatch/1453087-dispatch_semaphore_wait) 在使用过程中容易造成优先级反转问题
> If you use concurrency primitives, such as [dispatch_semaphore_wait](https://developer.apple.com/documentation/dispatch/1453087-dispatch_semaphore_wait) and [dispatch_group_wait](https://developer.apple.com/documentation/dispatch/1452794-dispatch_group_wait), in your code or invoke APIs that use them, your app is susceptible to priority inversions if there is a mismatch in the quality-of-service (QoS) class of the dispatch queues your app uses. When you use these primitives, the system can’t automatically propagate priority from the higher-priority thread to the lower-priority thread.

在原实现中，在同一时刻，GrowingLOG_MAX_QUEUE_SIZE + 1 次调用 dispatch_semaphore_wait 时，将服从系统调度，从空闲的非主线程执行，可能出现执行所在的线程 qos 大于正在持有 semaphore 的线程 qos，表现为：
```
Thread Performance Checker: Thread running at QOS_CLASS_USER_INITIATED waiting on a lower QoS thread running at QOS_CLASS_DEFAULT. Investigate ways to avoid priority inversions
PID: 11944, TID: 54569462
Backtrace
=================================================================
3   GrowingAnalytics                    0x000000010330c4cc __45-[GrowingLog queueLogMessage:asynchronously:]_block_invoke + 44
4   libdispatch.dylib                   0x00000001032245a8 _dispatch_call_block_and_release + 32
5   libdispatch.dylib                   0x000000010322605c _dispatch_client_callout + 20
6   libdispatch.dylib                   0x000000010322e10c _dispatch_lane_serial_drain + 988
7   libdispatch.dylib                   0x000000010322ee34 _dispatch_lane_invoke + 420
8   libdispatch.dylib                   0x000000010323bcbc _dispatch_workloop_worker_thread + 740
9   libsystem_pthread.dylib             0x000000020069bdf8 _pthread_wqthread + 288
10  libsystem_pthread.dylib             0x000000020069bb98 start_wqthread + 8
```


