### PR TITLE
fix: swift project building error

### DIFF
--- a/GrowingAutotracker-cdp/GrowingAutotracker.h
+++ b/GrowingAutotracker-cdp/GrowingAutotracker.h
@@ -17,10 +17,15 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#if __has_feature(modules)
+@import UIKit;
+@import GrowingAnalytics;
+#else
 #import <UIKit/UIKit.h>
 #import "GrowingAttributesBuilder.h"
 #import "GrowingAutotrackConfiguration.h"
 #import "GrowingDynamicProxy.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GrowingTracker-cdp/GrowingTracker.h
+++ b/GrowingTracker-cdp/GrowingTracker.h
@@ -17,9 +17,13 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#if __has_feature(modules)
+@import GrowingAnalytics;
+#else
 #import "GrowingAttributesBuilder.h"
 #import "GrowingDynamicProxy.h"
 #import "GrowingTrackConfiguration.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
## PR 内容

* fix: swift project building error about 'Include of non-modular header inside framework module'

## 测试步骤

* 新建 **Swift** 项目，使用 **Cocoapods** 集成 **GrowingAnalytics-cdp SDK** 进行测试

## 影响范围

* SDK 在 Swift 项目下使用 Cocoapods 集成后可正常编译

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

* 参考：*https://clang.llvm.org/docs/LanguageExtensions.html#modules*
* 如果 https://github.com/growingio/growingio-sdk-ios-autotracker/pull/250 合并，则此 PR 可作废
* 集成文档中，对应描述 - [Include of non-modular header inside framework module 报错解决方案](https://growingio.github.io/growingio-sdk-docs/docs/ios/Introduce#include-of-non-modular-header-inside-framework-module-%E6%8A%A5%E9%94%99%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88)，可在此 PR 合并后，删除或改成当所使用的 SDK 为对应 SDK 版本(3.3.5-<此 PR 合并前的版本>)情况下

