### PR TITLE
test: enable inspection of webView in iOS 16.4

### DIFF
--- a/Example/Example/UICategoryTests/H5Browser/GIODefaultWebViewController.m
+++ b/Example/Example/UICategoryTests/H5Browser/GIODefaultWebViewController.m
@@ -58,6 +58,11 @@
 - (WKWebView *)webView {
     if (!_webView) {
         _webView = [[WKWebView alloc] initWithFrame:self.view.bounds];
+#if defined(__IPHONE_16_4) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_4)
+        if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+            _webView.inspectable = YES;
+        }
+#endif
     }
     return _webView;
 }

--- a/Example/Example/UICategoryTests/Hybrid/GIOHybridViewController.m
+++ b/Example/Example/UICategoryTests/Hybrid/GIOHybridViewController.m
@@ -119,6 +119,11 @@
         _webView.navigationDelegate = self;
         _webView.backgroundColor = [UIColor whiteColor];
         _webView.accessibilityLabel = @"HybridWebView";
+#if defined(__IPHONE_16_4) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_4)
+        if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+            _webView.inspectable = YES;
+        }
+#endif
     }
     return _webView;
 }


### PR DESCRIPTION
使用 Xcode 14.3 链接 iOS SDK 16.4 编译时，需要设置 `webView.inspectable = YES; `，否则无法通过 Safari 调试