### PR TITLE
fix: verify deep link host

### DIFF
--- a/Example/Example/AppDelegate.m
+++ b/Example/Example/AppDelegate.m
@@ -47,7 +47,7 @@
     
 #if defined(SDKADVERTMODULE)
     configuration.ASAEnabled = YES;
-    configuration.deepLinkHost = @"https://datayi.cn";
+    configuration.deepLinkHost = @"https://n.datayi.cn";
     configuration.deepLinkCallback = ^(NSDictionary * _Nullable params, NSTimeInterval processTime, NSError * _Nullable error) {
         if (error) {
             NSLog(@"error = %@", error);

--- a/Example/Example/Example.entitlements
+++ b/Example/Example/Example.entitlements
@@ -5,7 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:testlink.growingio.com</string>
-		<string>applinks:datayi.cn</string>
+		<string>applinks:n.datayi.cn</string>
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>

--- a/Example/ExampleiOS13/ExampleiOS13.entitlements
+++ b/Example/ExampleiOS13/ExampleiOS13.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:datayi.cn</string>
+		<string>applinks:n.datayi.cn</string>
 	</array>
 </dict>
 </plist>

--- a/Modules/Advert/GrowingAdvertising.m
+++ b/Modules/Advert/GrowingAdvertising.m
@@ -65,6 +65,14 @@ NSString *const GrowingAdvertisingErrorDomain = @"com.growingio.advertising";
 }
 
 - (void)growingModInit:(GrowingContext *)context {
+    GrowingTrackConfiguration *config = GrowingConfigurationManager.sharedInstance.trackConfiguration;
+    if (config.deepLinkHost && config.deepLinkHost.length > 0) {
+        NSString *host = [NSURL URLWithString:config.deepLinkHost].host;
+        if (!host) {
+            @throw [NSException exceptionWithName:@"初始化异常" reason:@"您所配置的DeepLinkHost不符合规范" userInfo:nil];
+        }
+    }
+    
     self.builders = [NSMutableArray array];
     [[GrowingEventManager sharedInstance] addInterceptor:self];
     [[GrowingDeepLinkHandler sharedInstance] addHandlersObject:self];

--- a/Modules/Advert/GrowingAdvertising.m
+++ b/Modules/Advert/GrowingAdvertising.m
@@ -43,6 +43,8 @@
 
 GrowingMod(GrowingAdvertising)
 
+NSString * const GrowingAdDefaultDeepLinkHost = @"https://n.datayi.cn";
+
 NSString *const GrowingAdvertisingErrorDomain = @"com.growingio.advertising";
 
 @interface GrowingAdvertising () <GrowingDeepLinkHandlerProtocol, GrowingEventInterceptor, GrowingULAppLifecycleDelegate>

--- a/Modules/Advert/Public/GrowingAdvertising.h
+++ b/Modules/Advert/Public/GrowingAdvertising.h
@@ -29,6 +29,8 @@ typedef NS_ENUM(NSInteger , GrowingAdvertisingError) {
     GrowingAdvertisingRequestFailedError, /// 短链请求失败
 };
 
+FOUNDATION_EXPORT NSString *const GrowingAdDefaultDeepLinkHost;
+
 extern NSString *const GrowingAdvertisingErrorDomain;
 
 typedef void(^_Nullable GrowingAdDeepLinkCallback)(NSDictionary * _Nullable params,

--- a/Modules/Advert/Request/GrowingAdPreRequest.m
+++ b/Modules/Advert/Request/GrowingAdPreRequest.m
@@ -34,10 +34,10 @@
 - (NSURL *)absoluteURL {
     NSURL *baseURL;
     GrowingTrackConfiguration *config = GrowingConfigurationManager.sharedInstance.trackConfiguration;
-    if (config.deepLinkHost) {
+    if (config.deepLinkHost && config.deepLinkHost.length > 0) {
         baseURL = [NSURL URLWithString:config.deepLinkHost];
     } else {
-        baseURL = [NSURL URLWithString:@"https://t.growingio.com"];
+        baseURL = [NSURL URLWithString:GrowingAdDefaultDeepLinkHost];
     }
     return [NSURL URLWithString:self.path relativeToURL:baseURL];
 }

--- a/Modules/Advert/Utils/GrowingAdUtils.m
+++ b/Modules/Advert/Utils/GrowingAdUtils.m
@@ -80,11 +80,12 @@ static pthread_mutex_t _mutex;
     }
     
     GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
-    if (!trackConfiguration.deepLinkHost) {
-        return NO;
+    NSString *deepLinkHost = trackConfiguration.deepLinkHost;
+    if (!deepLinkHost || deepLinkHost.length == 0) {
+        deepLinkHost = GrowingAdDefaultDeepLinkHost;
     }
-    NSString *deepLinkHost = [NSURL URLWithString:trackConfiguration.deepLinkHost].host;
-    return ([url.host isEqualToString:deepLinkHost] || [url.host hasSuffix:deepLinkHost]);
+    NSString *host = [NSURL URLWithString:deepLinkHost].host;
+    return ([url.host isEqualToString:host] || [url.host hasSuffix:host]);
 }
 
 + (BOOL)isURLScheme:(NSURL *)url {


### PR DESCRIPTION
## PR 内容

* fix: default deep link host
* fix: verify deep link host

## 测试步骤

* 使用非法 deepLinkHost (如，包含空格、IP) 进行初始化，是否报错
* 初始化若未配置 deepLinkHost，将使用默认地址
