### PR TITLE
fix: some bugs in swift protobuf

### DIFF
--- a/Services/SwiftProtobuf/SwiftProtobuf.swift
+++ b/Services/SwiftProtobuf/SwiftProtobuf.swift
@@ -88,7 +88,7 @@ public class SwiftProtobufWrapper: NSObject {
         dto.referralPage = jsonObject["referralPage"] as? String ?? ""
         dto.protocolType = jsonObject["protocolType"] as? String ?? ""
         dto.eventName = jsonObject["eventName"] as? String ?? ""
-        dto.timezoneOffset = (jsonObject["timezoneOffset"] as? NSNumber)?.int32Value ?? 0
+        dto.timezoneOffset = jsonObject["timezoneOffset"] as? String ?? ""
 
         return SwiftProtobufWrapper(dto)
     }
@@ -201,7 +201,7 @@ public extension GrowingBaseEvent {
         dto.longitude = longitude
         dto.sdkVersion = sdkVersion
         dto.userKey = userKey ?? ""
-        dto.timezoneOffset = Int32(timezoneOffset)
+        dto.timezoneOffset = timezoneOffset
 
         dto.eventType = SwiftProtobufWrapper.eventType(eventType)
         dto.idfa = idfa()


### PR DESCRIPTION
* fix: swift protobuf 中 timezoneOffset 数据类型为 String
* fix: swift protobuf 中 toJson 后 timestamp 应为 Number 类型

见：https://github.com/growingio/growingio-sdk-ios-autotracker/pull/248#issuecomment-1515913736
> Int64 类型在 proto3 JSON Mapping 默认为 String 类型，apple/swift-protobuf 提供将 Int64 转为 Number，但截止 1.21.0 版本，尚未合并到发布分支上；对于 SDK运行过程中，~~toJSON 仅在打印调试日志 / Advert 模块获取 eventName 时调用，Int64 转 String 或 Number 并不影响功能正常执行；~~

现在 SDK 有 3.x 升到 4.x 的逻辑，如果在 3.x 集成了 SwiftProtobuf 模块产生了事件并且没发送，升级到 4.x 后又通过初始化配置 `config?.useProtobuf = false` 使用 JSON 类型发送该事件，那么经由 apple/swift-protobuf 转化过后的事件字段 `timestamp`（目前 SDK 中仅 timestamp 为 Int64）为 String 是不正确的，应该改成 Number