### PR TITLE
ci: spm.yml 中 xcodebuild 未主动报错

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingAutotracker -destination 'platform=iOS Simulator,name=iPhone 14' | xcpretty
+        run: xcodebuild build -scheme GrowingAutotracker -destination 'platform=iOS Simulator,name=iPhone 14' -quiet
 
   autotracker-build-catalyst:
     runs-on: macos-latest
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingAutotracker -destination 'platform=macOS,variant=Mac Catalyst' | xcpretty
+        run: xcodebuild build -scheme GrowingAutotracker -destination 'platform=macOS,variant=Mac Catalyst' -quiet
 
   tracker-build-iOS:
     runs-on: macos-latest
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingTracker -destination 'platform=iOS Simulator,name=iPhone 14' | xcpretty
+        run: xcodebuild build -scheme GrowingTracker -destination 'platform=iOS Simulator,name=iPhone 14' -quiet
 
   tracker-build-catalyst:
     runs-on: macos-latest
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingTracker -destination 'platform=macOS,variant=Mac Catalyst' | xcpretty
+        run: xcodebuild build -scheme GrowingTracker -destination 'platform=macOS,variant=Mac Catalyst' -quiet
 
   tracker-build-macos:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingTracker -destination 'platform=macOS' | xcpretty
+        run: xcodebuild build -scheme GrowingTracker -destination 'platform=macOS' -quiet
 
   advert-build-iOS:
     runs-on: macos-latest
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingModule_Advert -destination 'platform=iOS Simulator,name=iPhone 14' | xcpretty
+        run: xcodebuild build -scheme GrowingModule_Advert -destination 'platform=iOS Simulator,name=iPhone 14' -quiet
 
   apm-build-iOS:
     runs-on: macos-latest
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingModule_APM -destination 'platform=iOS Simulator,name=iPhone 14' | xcpretty
+        run: xcodebuild build -scheme GrowingModule_APM -destination 'platform=iOS Simulator,name=iPhone 14' -quiet
 
   apm-build-catalyst:
     runs-on: macos-latest
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingModule_APM -destination 'platform=macOS,variant=Mac Catalyst' | xcpretty
+        run: xcodebuild build -scheme GrowingModule_APM -destination 'platform=macOS,variant=Mac Catalyst' -quiet
 
   hybrid-build-iOS:
     runs-on: macos-latest
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingModule_Hybrid -destination 'platform=iOS Simulator,name=iPhone 14' | xcpretty
+        run: xcodebuild build -scheme GrowingModule_Hybrid -destination 'platform=iOS Simulator,name=iPhone 14' -quiet
 
   hybrid-build-catalyst:
     runs-on: macos-latest
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingModule_Hybrid -destination 'platform=macOS,variant=Mac Catalyst' | xcpretty
+        run: xcodebuild build -scheme GrowingModule_Hybrid -destination 'platform=macOS,variant=Mac Catalyst' -quiet
 
   imp-build-iOS:
     runs-on: macos-latest
@@ -117,4 +117,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: xcodebuild build -scheme GrowingModule_ImpressionTrack -destination 'platform=iOS Simulator,name=iPhone 14' | xcpretty
+        run: xcodebuild build -scheme GrowingModule_ImpressionTrack -destination 'platform=iOS Simulator,name=iPhone 14' -quiet


### PR DESCRIPTION
之前 xcodebuild 产生的日志通过 xcpretty 打印，导致 xcodebuild 就算出错，也会产出日志，转到 xcpretty。这种场景下，整个 job 也算执行成功。因此，https://github.com/growingio/growingio-sdk-ios-autotracker/commit/ed7751bcc78db497fbfdf1d8dc744890dff0b446 改动前，没有判定出异常