### PR TITLE
fix: update spm dependency version

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -3,10 +3,6 @@ name: SPM
 on:
   push:
     branches: [ master ]
-  workflow_run:
-    workflows: [Code Format]
-    types:
-      - completed
 
 jobs:
   autotracker-build-iOS:

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/growingio/growingio-sdk-ios-performance-ext.git",
-            "0.0.16" ..< "1.0.0"
+            "1.0.0" ..< "2.0.0"
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",


### PR DESCRIPTION
SDK 4.0.0 开始，由于接口改动的原因，utils/performance 都以 version 1.0.0 来依赖，与 SDK 3.x 区分开