### PR TITLE
fix: rename projectId to accountId

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		34BF77C92795571000CA18BA /* MockEventQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 4962653324DA66B600032551 /* MockEventQueue.m */; };
 		34BF77CB279562AC00CA18BA /* ManualTrackHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4962653224DA66B600032551 /* ManualTrackHelper.m */; };
 		34C0BF3A277EA7C90047ADC4 /* DataTrafficTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 34C0BF39277EA7C90047ADC4 /* DataTrafficTest.m */; };
+		34ECD0FF2AE22F3A00DA3EBD /* GrowingAnalyticsStartTests2.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ECD0FE2AE22F3A00DA3EBD /* GrowingAnalyticsStartTests2.m */; };
 		34ECFDBF2A5C082A0059F87C /* GrowingAutotrackPageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ECFDBE2A5C082A0059F87C /* GrowingAutotrackPageViewController.m */; };
 		34FCF7E12A937ECA009611B3 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FCF7E02A937ECA009611B3 /* SwiftUIView.swift */; };
 		34FCF7E42A937F4F009611B3 /* GIOSwiftUIContentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FCF7E32A937F4F009611B3 /* GIOSwiftUIContentViewController.m */; };
@@ -408,6 +409,7 @@
 		34BF77C52795568B00CA18BA /* GrowingKeyChainTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GrowingKeyChainTest.m; sourceTree = "<group>"; };
 		34C0BF39277EA7C90047ADC4 /* DataTrafficTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DataTrafficTest.m; sourceTree = "<group>"; };
 		34C0BF3C277EA9BA0047ADC4 /* MobileDebuggerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MobileDebuggerTest.m; sourceTree = "<group>"; };
+		34ECD0FE2AE22F3A00DA3EBD /* GrowingAnalyticsStartTests2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GrowingAnalyticsStartTests2.m; sourceTree = "<group>"; };
 		34ECFDBD2A5C082A0059F87C /* GrowingAutotrackPageViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GrowingAutotrackPageViewController.h; sourceTree = "<group>"; };
 		34ECFDBE2A5C082A0059F87C /* GrowingAutotrackPageViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GrowingAutotrackPageViewController.m; sourceTree = "<group>"; };
 		34F94ED82A938725002CB9FC /* Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Example-Bridging-Header.h"; path = "Example/Example-Bridging-Header.h"; sourceTree = SOURCE_ROOT; };
@@ -982,6 +984,7 @@
 			isa = PBXGroup;
 			children = (
 				34AB4E49279000F5002549FF /* GrowingAnalyticsStartTests.m */,
+				34ECD0FE2AE22F3A00DA3EBD /* GrowingAnalyticsStartTests2.m */,
 			);
 			path = GrowingAnalyticsStartTests;
 			sourceTree = "<group>";
@@ -2224,6 +2227,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				34ECD0FF2AE22F3A00DA3EBD /* GrowingAnalyticsStartTests2.m in Sources */,
 				34AB4E4A279000F5002549FF /* GrowingAnalyticsStartTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Example/AppDelegate.m
+++ b/Example/Example/AppDelegate.m
@@ -42,7 +42,7 @@
 }
 
 - (void)SDK3rdStart {
-    GrowingSDKConfiguration *configuration = [GrowingSDKConfiguration configurationWithProjectId:@"0a1b4118dd954ec3bcc69da5138bdb96"];
+    GrowingSDKConfiguration *configuration = [GrowingSDKConfiguration configurationWithAccountId:@"0a1b4118dd954ec3bcc69da5138bdb96"];
     configuration.debugEnabled = YES;
     configuration.idMappingEnabled = YES;
     configuration.dataSourceId = @"ab555003531e0fd1";

--- a/Example/ExampleiOS13/AppDelegate.m
+++ b/Example/ExampleiOS13/AppDelegate.m
@@ -22,8 +22,6 @@
 @import GrowingAnalytics;
 #import "GrowingAdvertising.h"
 
-static NSString *const kGrowingProjectId = @"bc675c65b3b0290e";
-
 @interface AppDelegate ()
 
 @end
@@ -33,7 +31,7 @@ static NSString *const kGrowingProjectId = @"bc675c65b3b0290e";
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
-    GrowingAutotrackConfiguration *configuration = [GrowingAutotrackConfiguration configurationWithProjectId:kGrowingProjectId];
+    GrowingAutotrackConfiguration *configuration = [GrowingAutotrackConfiguration configurationWithAccountId:@"bc675c65b3b0290e"];
     configuration.dataSourceId = @"1234567890";
     configuration.debugEnabled = YES;
     // 暂时设置host为mocky链接，防止请求404，实际是没有上传到服务器的，正式使用请去掉，或设置正确的host

--- a/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
+++ b/Example/GrowingAnalyticsTests/A0GrowingAnalyticsTest.m
@@ -59,7 +59,7 @@ static NSString *const kGrowingEventDuration = @"event_duration";
 - (void)test01InitializedSuccessfully {
     XCTAssertFalse([GrowingAutotracker isInitializedSuccessfully]);
     
-    GrowingAutotrackConfiguration *configuration = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
+    GrowingAutotrackConfiguration *configuration = [GrowingAutotrackConfiguration configurationWithAccountId:@"test"];
     configuration.dataSourceId = @"test";
     configuration.idMappingEnabled = YES;
     configuration.sessionInterval = 3.0f;

--- a/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/NSNotificationCenterAutotrackTest.m
+++ b/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/NSNotificationCenterAutotrackTest.m
@@ -55,7 +55,7 @@ AutotrackXCTestClassDefine(UITextField) AutotrackXCTestClassDefine(UITextView)
 @implementation NSNotificationCenterAutotrackTest
 
 + (void)setUp {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
     // 避免不执行readPropertyInTrackThread
     config.dataCollectionEnabled = YES;
     GrowingConfigurationManager.sharedInstance.trackConfiguration = config;

--- a/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/UICollectionViewAutotrackTest.m
+++ b/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/UICollectionViewAutotrackTest.m
@@ -97,7 +97,7 @@
 @implementation UICollectionViewAutotrackTest
 
 + (void)setUp {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
     // 避免不执行readPropertyInTrackThread
     config.dataCollectionEnabled = YES;
     GrowingConfigurationManager.sharedInstance.trackConfiguration = config;

--- a/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/UITableViewAutotrackTest.m
+++ b/Example/GrowingAnalyticsTests/AutotrackerCoreTests/Autotrack/UITableViewAutotrackTest.m
@@ -97,7 +97,7 @@
 @implementation UITableViewAutotrackTest
 
 + (void)setUp {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
     // 避免不执行readPropertyInTrackThread
     config.dataCollectionEnabled = YES;
     GrowingConfigurationManager.sharedInstance.trackConfiguration = config;

--- a/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests.m
+++ b/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests.m
@@ -48,7 +48,7 @@
 - (void)testGrowingTrackerStart {
     XCTAssertThrowsSpecificNamed(GrowingTracker.sharedInstance, NSException, @"GrowingTracker未初始化");
 
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"xctest"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"xctest"];
     XCTAssertThrowsSpecificNamed([GrowingTracker startWithConfiguration:config launchOptions:nil],
                                  NSException,
                                  @"初始化异常");
@@ -64,7 +64,7 @@
         }
                   waitUntilDone:YES];
 
-    GrowingTrackConfiguration *config2 = [GrowingTrackConfiguration configurationWithProjectId:@""];
+    GrowingTrackConfiguration *config2 = [GrowingTrackConfiguration configurationWithAccountId:@""];
     XCTAssertThrowsSpecificNamed([GrowingTracker startWithConfiguration:config2 launchOptions:nil],
                                  NSException,
                                  @"初始化异常");
@@ -73,7 +73,7 @@
 - (void)testGrowingAutotrackerStart {
     XCTAssertThrowsSpecificNamed(GrowingAutotracker.sharedInstance, NSException, @"GrowingAutotracker未初始化");
 
-    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithProjectId:@"xctest"];
+    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithAccountId:@"xctest"];
     XCTAssertThrowsSpecificNamed([GrowingAutotracker startWithConfiguration:config launchOptions:nil],
                                  NSException,
                                  @"初始化异常");
@@ -89,7 +89,7 @@
         }
                   waitUntilDone:YES];
 
-    GrowingAutotrackConfiguration *config2 = [GrowingAutotrackConfiguration configurationWithProjectId:@""];
+    GrowingAutotrackConfiguration *config2 = [GrowingAutotrackConfiguration configurationWithAccountId:@""];
     XCTAssertThrowsSpecificNamed([GrowingAutotracker startWithConfiguration:config2 launchOptions:nil],
                                  NSException,
                                  @"初始化异常");
@@ -98,7 +98,7 @@
 #pragma clang diagnostic pop
 
 - (void)testDefaultConfiguration_Autotracker {
-    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
+    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithAccountId:@"test"];
     [GrowingRealAutotracker trackerWithConfiguration:config launchOptions:nil];
 
     GrowingAutotrackConfiguration *configuration =
@@ -120,7 +120,7 @@
 }
 
 - (void)testSetConfiguration_Autotracker {
-    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
+    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithAccountId:@"test"];
     config.debugEnabled = YES;
     config.cellularDataLimit = 5;
     config.dataUploadInterval = 10;
@@ -156,7 +156,7 @@
 }
 
 - (void)testDefaultConfiguration_Tracker {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
     [GrowingRealTracker trackerWithConfiguration:config launchOptions:nil];
 
     GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
@@ -176,7 +176,7 @@
 }
 
 - (void)testSetConfiguration_Tracker {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
     config.debugEnabled = YES;
     config.cellularDataLimit = 5;
     config.dataUploadInterval = 10;

--- a/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests2.m
+++ b/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests2.m
@@ -1,9 +1,9 @@
 //
-//  GrowingAnalyticsStartTests.m
+//  GrowingAnalyticsStartTests2.m
 //  GrowingAnalytics
 //
-//  Created by YoloMao on 2022/1/13.
-//  Copyright (C) 2021 Beijing Yishu Technology Co., Ltd.
+//  Created by YoloMao on 2023/10/20.
+//  Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -28,11 +28,12 @@
 #import "GrowingTrackerCore/Manager/GrowingConfigurationManager.h"
 #import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
 
-@interface GrowingAnalyticsStartTests : XCTestCase
+// 对老版本API configurationWithProjectId的测试
+@interface GrowingAnalyticsStartTests2 : XCTestCase
 
 @end
 
-@implementation GrowingAnalyticsStartTests
+@implementation GrowingAnalyticsStartTests2
 
 - (void)setUp {
     // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -42,73 +43,8 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-
-- (void)testGrowingTrackerStart {
-    XCTAssertThrowsSpecificNamed(GrowingTracker.sharedInstance, NSException, @"GrowingTracker未初始化");
-
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"xctest"];
-    XCTAssertThrowsSpecificNamed([GrowingTracker startWithConfiguration:config launchOptions:nil],
-                                 NSException,
-                                 @"初始化异常");
-
-    config.dataSourceId = @"xctest";
-    [GrowingTracker startWithConfiguration:config launchOptions:nil];
-
-    [GrowingDispatchManager
-        dispatchInGrowingThread:^{
-            XCTAssertThrowsSpecificNamed([GrowingTracker startWithConfiguration:config launchOptions:nil],
-                                         NSException,
-                                         @"初始化异常");
-        }
-                  waitUntilDone:YES];
-
-    GrowingTrackConfiguration *config2 = [GrowingTrackConfiguration configurationWithAccountId:@""];
-    XCTAssertThrowsSpecificNamed([GrowingTracker startWithConfiguration:config2 launchOptions:nil],
-                                 NSException,
-                                 @"初始化异常");
-    
-    GrowingTrackConfiguration *config3 = [GrowingTrackConfiguration configurationWithAccountId:nil];
-    XCTAssertThrowsSpecificNamed([GrowingTracker startWithConfiguration:config3 launchOptions:nil],
-                                 NSException,
-                                 @"初始化异常");
-}
-
-- (void)testGrowingAutotrackerStart {
-    XCTAssertThrowsSpecificNamed(GrowingAutotracker.sharedInstance, NSException, @"GrowingAutotracker未初始化");
-
-    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithAccountId:@"xctest"];
-    XCTAssertThrowsSpecificNamed([GrowingAutotracker startWithConfiguration:config launchOptions:nil],
-                                 NSException,
-                                 @"初始化异常");
-
-    config.dataSourceId = @"xctest";
-    [GrowingAutotracker startWithConfiguration:config launchOptions:nil];
-
-    [GrowingDispatchManager
-        dispatchInGrowingThread:^{
-            XCTAssertThrowsSpecificNamed([GrowingAutotracker startWithConfiguration:config launchOptions:nil],
-                                         NSException,
-                                         @"初始化异常");
-        }
-                  waitUntilDone:YES];
-
-    GrowingAutotrackConfiguration *config2 = [GrowingAutotrackConfiguration configurationWithAccountId:@""];
-    XCTAssertThrowsSpecificNamed([GrowingAutotracker startWithConfiguration:config2 launchOptions:nil],
-                                 NSException,
-                                 @"初始化异常");
-    
-    GrowingAutotrackConfiguration *config3 = [GrowingAutotrackConfiguration configurationWithAccountId:nil];
-    XCTAssertThrowsSpecificNamed([GrowingAutotracker startWithConfiguration:config3 launchOptions:nil],
-                                 NSException,
-                                 @"初始化异常");
-}
-
-#pragma clang diagnostic pop
-
 - (void)testDefaultConfiguration_Autotracker {
-    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithAccountId:@"test"];
+    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
     [GrowingRealAutotracker trackerWithConfiguration:config launchOptions:nil];
 
     GrowingAutotrackConfiguration *configuration =
@@ -130,7 +66,7 @@
 }
 
 - (void)testSetConfiguration_Autotracker {
-    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithAccountId:@"test"];
+    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
     config.debugEnabled = YES;
     config.cellularDataLimit = 5;
     config.dataUploadInterval = 10;
@@ -166,7 +102,7 @@
 }
 
 - (void)testDefaultConfiguration_Tracker {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
     [GrowingRealTracker trackerWithConfiguration:config launchOptions:nil];
 
     GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
@@ -186,7 +122,7 @@
 }
 
 - (void)testSetConfiguration_Tracker {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
     config.debugEnabled = YES;
     config.cellularDataLimit = 5;
     config.dataUploadInterval = 10;
@@ -216,16 +152,6 @@
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.tracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
-}
-
-- (void)testVersionNameAndVersionCode {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-    NSString *versionName = [GrowingRealTracker performSelector:@selector(versionName)];
-    NSString *versionCode = [GrowingRealTracker performSelector:@selector(versionCode)];
-    XCTAssertNotNil(versionName);
-    XCTAssertNotNil(versionCode);
-#pragma clang diagnostic pop
 }
 
 @end

--- a/Example/GrowingAnalyticsTests/ModulesTests/AdvertTests/AdvertTest.m
+++ b/Example/GrowingAnalyticsTests/ModulesTests/AdvertTests/AdvertTest.m
@@ -47,7 +47,7 @@
 }
 
 - (void)test00SendActivateEvent {
-    GrowingAutotrackConfiguration *configuration = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
+    GrowingAutotrackConfiguration *configuration = [GrowingAutotrackConfiguration configurationWithAccountId:@"test"];
     configuration.dataSourceId = @"test";
     configuration.urlScheme = @"growing.530c8231345c492d";
     configuration.readClipboardEnabled = NO;

--- a/Example/GrowingAnalyticsTests/ModulesTests/HybridTests/HybridTest.m
+++ b/Example/GrowingAnalyticsTests/ModulesTests/HybridTests/HybridTest.m
@@ -56,7 +56,7 @@
     [GrowingServiceManager.sharedInstance registerService:@protocol(GrowingPBEventDatabaseService)
                                                 implClass:GrowingEventProtobufDatabase.class];
     [GrowingSession startSession];
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
     config.idMappingEnabled = YES;
     GrowingConfigurationManager.sharedInstance.trackConfiguration = config;
 }

--- a/Example/GrowingAnalyticsTests/ModulesTests/ProtobufTests/ProtobufRequestHeaderTest.m
+++ b/Example/GrowingAnalyticsTests/ModulesTests/ProtobufTests/ProtobufRequestHeaderTest.m
@@ -39,7 +39,7 @@
 }
 
 - (void)test01RequestHeaderProtobufFirst {
-    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
+    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithAccountId:@"test"];
     config.useProtobuf = YES;
     [GrowingRealAutotracker trackerWithConfiguration:config launchOptions:nil];
 
@@ -63,7 +63,7 @@
 }
 
 - (void)test02RequestHeaderJSONFirst {
-    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
+    GrowingAutotrackConfiguration *config = [GrowingAutotrackConfiguration configurationWithAccountId:@"test"];
     config.useProtobuf = NO;
     [GrowingRealAutotracker trackerWithConfiguration:config launchOptions:nil];
 

--- a/Example/GrowingAnalyticsTests/TrackerCoreTests/EventTests/EventTest.m
+++ b/Example/GrowingAnalyticsTests/TrackerCoreTests/EventTests/EventTest.m
@@ -44,7 +44,7 @@
 @implementation EventTest
 
 + (void)setUp {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
     config.dataSourceId = @"test";
 
     // 避免不执行readPropertyInTrackThread

--- a/Example/GrowingAnalyticsTests/TrackerCoreTests/ManagerTests/GrowingSessionTest.m
+++ b/Example/GrowingAnalyticsTests/TrackerCoreTests/ManagerTests/GrowingSessionTest.m
@@ -35,7 +35,7 @@
 @implementation GrowingSessionTest
 
 + (void)setUp {
-    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithProjectId:@"test"];
+    GrowingTrackConfiguration *config = [GrowingTrackConfiguration configurationWithAccountId:@"test"];
     // 避免不执行readPropertyInTrackThread
     config.dataCollectionEnabled = YES;
     config.sessionInterval = 3.0f;

--- a/GrowingAutotracker/GrowingAutotracker.m
+++ b/GrowingAutotracker/GrowingAutotracker.m
@@ -40,8 +40,8 @@ static GrowingAutotracker *sharedInstance = nil;
                      userInfo:nil];
     }
 
-    if (!configuration.projectId.length) {
-        @throw [NSException exceptionWithName:@"初始化异常" reason:@"ProjectId不能为空" userInfo:nil];
+    if (!configuration.accountId.length) {
+        @throw [NSException exceptionWithName:@"初始化异常" reason:@"AccountId不能为空" userInfo:nil];
     }
 
     if (!configuration.dataSourceId.length) {

--- a/GrowingAutotrackerCore/GrowingAutotrackConfiguration.m
+++ b/GrowingAutotrackerCore/GrowingAutotrackConfiguration.m
@@ -30,8 +30,8 @@
     GROWING_LOCK_DECLARE(lock);
 }
 
-- (instancetype)initWithProjectId:(NSString *)projectId {
-    if (self = [super initWithProjectId:projectId]) {
+- (instancetype)initWithAccountId:(NSString *)accountId {
+    if (self = [super initWithAccountId:accountId]) {
         _autotrackEnabled = YES;
         _impressionScale = 0.0f;
         GROWING_LOCK_INIT(lock);

--- a/GrowingTracker/GrowingTracker.m
+++ b/GrowingTracker/GrowingTracker.m
@@ -42,8 +42,8 @@ static GrowingTracker *sharedInstance = nil;
                      userInfo:nil];
     }
 
-    if (!configuration.projectId.length) {
-        @throw [NSException exceptionWithName:@"初始化异常" reason:@"ProjectId不能为空" userInfo:nil];
+    if (!configuration.accountId.length) {
+        @throw [NSException exceptionWithName:@"初始化异常" reason:@"AccountId不能为空" userInfo:nil];
     }
 
     if (!configuration.dataSourceId.length) {

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -228,13 +228,6 @@ static GrowingEventManager *sharedInstance = nil;
 
 // 非安全 发送日志
 - (void)sendEventsOfChannel_unsafe:(GrowingEventChannel *)channel {
-    GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
-    NSString *projectId = trackConfiguration.projectId;
-    if (projectId.length == 0) {
-        GIOLogError(@"No valid ProjectId (channel = %@).", channel.name);
-        return;
-    }
-
     if (channel.isUploading) {
         return;
     }
@@ -296,6 +289,7 @@ static GrowingEventManager *sharedInstance = nil;
 #endif
 
     NSData *rawEvents = nil;
+    GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
     if ((channel.persistenceType == GrowingEventPersistenceTypeJSON && trackConfiguration.useProtobuf) ||
         (channel.persistenceType == GrowingEventPersistenceTypeProtobuf && !trackConfiguration.useProtobuf)) {
         // 该channel的持久化数据格式与配置不同，需要转换为配置的数据格式

--- a/GrowingTrackerCore/GrowingTrackConfiguration.m
+++ b/GrowingTrackerCore/GrowingTrackConfiguration.m
@@ -37,10 +37,10 @@ NSString *const kGrowingDefaultDataCollectionServerHost = @"https://napi.growing
 
 @implementation GrowingTrackConfiguration
 
-- (instancetype)initWithProjectId:(NSString *)projectId {
+- (instancetype)initWithAccountId:(NSString *)accountId {
     self = [super init];
     if (self) {
-        _projectId = [projectId copy];
+        _accountId = [accountId copy];
         _dataSourceId = nil;
 
         _debugEnabled = NO;
@@ -70,13 +70,17 @@ NSString *const kGrowingDefaultDataCollectionServerHost = @"https://napi.growing
     return self;
 }
 
-+ (instancetype)configurationWithProjectId:(NSString *)projectId {
-    return [[self alloc] initWithProjectId:projectId];
++ (instancetype)configurationWithAccountId:(NSString *)accountId {
+    return [[self alloc] initWithAccountId:accountId];
+}
+
++ (instancetype)configurationWithProjectId:(NSString *)accountId {
+    return [self configurationWithAccountId:accountId];
 }
 
 - (id)copyWithZone:(NSZone *)zone {
     GrowingTrackConfiguration *configuration = [[[self class] allocWithZone:zone] init];
-    configuration->_projectId = [_projectId copy];
+    configuration->_accountId = [_accountId copy];
     configuration->_dataSourceId = [_dataSourceId copy];
     configuration->_debugEnabled = _debugEnabled;
     configuration->_cellularDataLimit = _cellularDataLimit;

--- a/GrowingTrackerCore/Network/Request/GrowingEventRequest.m
+++ b/GrowingTrackerCore/Network/Request/GrowingEventRequest.m
@@ -54,7 +54,7 @@
 }
 
 - (NSString *)path {
-    NSString *accountId = [GrowingConfigurationManager sharedInstance].trackConfiguration.projectId ?: @"";
+    NSString *accountId = [GrowingConfigurationManager sharedInstance].trackConfiguration.accountId;
     NSString *path = [NSString stringWithFormat:@"v3/projects/%@/collect", accountId];
     return path;
 }

--- a/GrowingTrackerCore/Network/Request/GrowingNetworkConfig.m
+++ b/GrowingTrackerCore/Network/Request/GrowingNetworkConfig.m
@@ -45,7 +45,7 @@ static GrowingNetworkConfig *sharedInstance;
 }
 
 + (NSString *)path {
-    NSString *accountId = [GrowingConfigurationManager sharedInstance].trackConfiguration.projectId ?: @"";
+    NSString *accountId = [GrowingConfigurationManager sharedInstance].trackConfiguration.accountId;
     NSString *path = [NSString stringWithFormat:@"v3/projects/%@/collect", accountId];
     return path;
 }

--- a/GrowingTrackerCore/Public/GrowingTrackConfiguration.h
+++ b/GrowingTrackerCore/Public/GrowingTrackConfiguration.h
@@ -25,7 +25,7 @@ FOUNDATION_EXPORT NSString *const kGrowingDefaultDataCollectionServerHost;
 
 @interface GrowingTrackConfiguration : NSObject <NSCopying>
 
-@property (nonatomic, copy, readonly) NSString *projectId;
+@property (nonatomic, copy, readonly) NSString *accountId;
 @property (nonatomic, copy) NSString *dataSourceId;
 @property (nonatomic, assign) BOOL debugEnabled;
 @property (nonatomic, assign) NSUInteger cellularDataLimit;
@@ -41,8 +41,9 @@ FOUNDATION_EXPORT NSString *const kGrowingDefaultDataCollectionServerHost;
 @property (nonatomic, assign) BOOL encryptEnabled;
 @property (nonatomic, assign) BOOL useProtobuf;
 
-- (instancetype)initWithProjectId:(NSString *)projectId;
+- (instancetype)initWithAccountId:(NSString *)accountId;
 
-+ (instancetype)configurationWithProjectId:(NSString *)projectId;
++ (instancetype)configurationWithAccountId:(NSString *)accountId;
++ (instancetype)configurationWithProjectId:(NSString *)accountId;
 
 @end

--- a/Modules/Advert/Request/GrowingAdPreRequest.m
+++ b/Modules/Advert/Request/GrowingAdPreRequest.m
@@ -44,8 +44,8 @@
 
 - (NSString *)path {
     GrowingTrackConfiguration *config = GrowingConfigurationManager.sharedInstance.trackConfiguration;
-    NSString *projectKey = config.projectId ?: @"";
-    NSString *datasourceId = config.dataSourceId ?: @"";
+    NSString *projectKey = config.accountId;
+    NSString *datasourceId = config.dataSourceId;
     NSString *path = [NSString stringWithFormat:@"deep/v1/%@/ios/%@/%@/%@",
                                                 self.isManual ? @"inapp" : @"defer",
                                                 projectKey,

--- a/Modules/Hybrid/GrowingWKWebViewJavascriptBridge.m
+++ b/Modules/Hybrid/GrowingWKWebViewJavascriptBridge.m
@@ -92,11 +92,11 @@ static NSString *const kGrowingWKWebViewJavascriptBridge = @"GrowingWKWebViewJav
         }];
 
         if (!isContainUserScripts) {
-            NSString *projectId = GrowingConfigurationManager.sharedInstance.trackConfiguration.projectId;
+            NSString *accountId = GrowingConfigurationManager.sharedInstance.trackConfiguration.accountId;
             NSString *bundleId = [GrowingDeviceInfo currentDeviceInfo].bundleID;
             NSString *urlScheme = [GrowingDeviceInfo currentDeviceInfo].urlScheme;
             GrowingWebViewJavascriptBridgeConfiguration *config =
-                [GrowingWebViewJavascriptBridgeConfiguration configurationWithProjectId:projectId
+                [GrowingWebViewJavascriptBridgeConfiguration configurationWithAccountId:accountId
                                                                                   appId:urlScheme
                                                                              appPackage:bundleId
                                                                        nativeSdkVersion:GrowingTrackerVersionName

--- a/Modules/Hybrid/GrowingWebViewJavascriptBridgeConfiguration.h
+++ b/Modules/Hybrid/GrowingWebViewJavascriptBridgeConfiguration.h
@@ -20,19 +20,19 @@
 #import <Foundation/Foundation.h>
 
 @interface GrowingWebViewJavascriptBridgeConfiguration : NSObject
-@property (nonatomic, readonly, copy) NSString *projectId;
+@property (nonatomic, readonly, copy) NSString *accountId;
 @property (nonatomic, readonly, copy) NSString *appId;
 @property (nonatomic, readonly, copy) NSString *appPackage;
 @property (nonatomic, readonly, copy) NSString *nativeSdkVersion;
 @property (nonatomic, readonly, assign) int nativeSdkVersionCode;
 
-- (instancetype)initWithProjectId:(NSString *)projectId
+- (instancetype)initWithAccountId:(NSString *)accountId
                             appId:(NSString *)appId
                        appPackage:(NSString *)appPackage
                  nativeSdkVersion:(NSString *)nativeSdkVersion
              nativeSdkVersionCode:(int)nativeSdkVersionCode;
 
-+ (instancetype)configurationWithProjectId:(NSString *)projectId
++ (instancetype)configurationWithAccountId:(NSString *)accountId
                                      appId:(NSString *)appId
                                 appPackage:(NSString *)appPackage
                           nativeSdkVersion:(NSString *)nativeSdkVersion

--- a/Modules/Hybrid/GrowingWebViewJavascriptBridgeConfiguration.m
+++ b/Modules/Hybrid/GrowingWebViewJavascriptBridgeConfiguration.m
@@ -51,14 +51,11 @@
 }
 
 - (NSString *)toJsonString {
-    NSMutableDictionary *configuration = [self dictionaryWithValuesForKeys:@[
-        @"appId",
-        @"appPackage",
-        @"nativeSdkVersion",
-        @"nativeSdkVersionCode"
-    ]].mutableCopy;
+    NSMutableDictionary *configuration =
+        [self dictionaryWithValuesForKeys:@[@"appId", @"appPackage", @"nativeSdkVersion", @"nativeSdkVersionCode"]]
+            .mutableCopy;
     configuration[@"projectId"] = self.accountId;
-    
+
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:configuration
                                                        options:NSJSONWritingPrettyPrinted

--- a/Modules/Hybrid/GrowingWebViewJavascriptBridgeConfiguration.m
+++ b/Modules/Hybrid/GrowingWebViewJavascriptBridgeConfiguration.m
@@ -21,14 +21,14 @@
 
 @implementation GrowingWebViewJavascriptBridgeConfiguration
 
-- (instancetype)initWithProjectId:(NSString *)projectId
+- (instancetype)initWithAccountId:(NSString *)accountId
                             appId:(NSString *)appId
                        appPackage:(NSString *)appPackage
                  nativeSdkVersion:(NSString *)nativeSdkVersion
              nativeSdkVersionCode:(int)nativeSdkVersionCode {
     self = [super init];
     if (self) {
-        _projectId = [projectId copy];
+        _accountId = [accountId copy];
         _appId = [appId copy];
         _appPackage = [appPackage copy];
         _nativeSdkVersion = [nativeSdkVersion copy];
@@ -38,12 +38,12 @@
     return self;
 }
 
-+ (instancetype)configurationWithProjectId:(NSString *)projectId
++ (instancetype)configurationWithAccountId:(NSString *)accountId
                                      appId:(NSString *)appId
                                 appPackage:(NSString *)appPackage
                           nativeSdkVersion:(NSString *)nativeSdkVersion
                       nativeSdkVersionCode:(int)nativeSdkVersionCode {
-    return [[self alloc] initWithProjectId:projectId
+    return [[self alloc] initWithAccountId:accountId
                                      appId:appId
                                 appPackage:appPackage
                           nativeSdkVersion:nativeSdkVersion
@@ -51,13 +51,14 @@
 }
 
 - (NSString *)toJsonString {
-    NSDictionary *configuration = [self dictionaryWithValuesForKeys:@[
-        @"projectId",
+    NSMutableDictionary *configuration = [self dictionaryWithValuesForKeys:@[
         @"appId",
         @"appPackage",
         @"nativeSdkVersion",
         @"nativeSdkVersionCode"
-    ]];
+    ]].mutableCopy;
+    configuration[@"projectId"] = self.accountId;
+    
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:configuration
                                                        options:NSJSONWritingPrettyPrinted

--- a/Modules/MobileDebugger/GrowingMobileDebugger.m
+++ b/Modules/MobileDebugger/GrowingMobileDebugger.m
@@ -355,9 +355,9 @@ GrowingMod(GrowingMobileDebugger)
 
 - (void)webSocketDidOpen:(id<GrowingWebSocketService>)webSocket {
     GIOLogDebug(@"websocket已连接");
-    NSString *projectId = GrowingConfigurationManager.sharedInstance.trackConfiguration.projectId;
+    NSString *accountId = GrowingConfigurationManager.sharedInstance.trackConfiguration.accountId;
     NSDictionary *dict = @{
-        @"projectId": projectId,
+        @"projectId": accountId,
         @"msgType": @"ready",
         @"timestamp": @([GrowingULTimeUtil currentTimeMillis]),
         @"domain": [GrowingDeviceInfo currentDeviceInfo].bundleID,

--- a/Modules/WebCircle/GrowingWebCircle.m
+++ b/Modules/WebCircle/GrowingWebCircle.m
@@ -499,9 +499,9 @@ GrowingMod(GrowingWebCircle)
 
 - (void)webSocketDidOpen:(id<GrowingWebSocketService>)webSocket {
     GIOLogDebug(@"[GrowingWebCircle] websocket已连接");
-    NSString *projectId = GrowingConfigurationManager.sharedInstance.trackConfiguration.projectId;
+    NSString *accountId = GrowingConfigurationManager.sharedInstance.trackConfiguration.accountId;
     NSDictionary *dict = @{
-        @"projectId": projectId,
+        @"projectId": accountId,
         @"msgType": @"ready",
         @"timestamp": @([[NSDate date] timeIntervalSince1970]),
         @"domain": [GrowingDeviceInfo currentDeviceInfo].bundleID,


### PR DESCRIPTION
* 将 SDK 中 projectId 重命名为 accountId，与平台一致
* 兼容 Flutter SDK 等其他库，保留 `configurationWithProjectId `调用方式
* MobileDebugger 和 WebCircle 中，**ready** 消息内容还是以 `projectId` 作为 key
* `GrowingWebViewJavascriptBridge.configuration` 还是以 `projectId` 作为 key