### PR TITLE
fix: swift project building error

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Deploy to Cocoapods
         run: |
           set -eo pipefail
-          pod trunk push GrowingAnalytics.podspec --verbose --allow-warnings --use-libraries
-          pod trunk push GrowingAnalytics-cdp.podspec --verbose --allow-warnings --use-libraries --synchronous
+          pod trunk push GrowingAnalytics.podspec --verbose --allow-warnings
+          pod trunk push GrowingAnalytics-cdp.podspec --verbose --allow-warnings --synchronous
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/Example/GrowingAnalyticsTests/TrackerCoreTests/DeepLinkTests/DeepLinkTest.m
+++ b/Example/GrowingAnalyticsTests/TrackerCoreTests/DeepLinkTests/DeepLinkTest.m
@@ -46,6 +46,7 @@
 
 - (BOOL)growingHandlerUrl:(NSURL *)url {
     XCTAssertEqualObjects(url.absoluteString, @"https://www.baidu.com");
+    return YES;
 }
 
 @end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,71 +1,71 @@
 PODS:
-  - GrowingAnalytics-cdp/Autotracker (3.7.0):
-    - GrowingAnalytics/AutotrackerCore (= 3.7.0)
-    - GrowingAnalytics/DefaultServices (= 3.7.0)
-    - GrowingAnalytics/Hybrid (= 3.7.0)
-    - GrowingAnalytics/MobileDebugger (= 3.7.0)
-    - GrowingAnalytics/WebCircle (= 3.7.0)
-  - GrowingAnalytics-cdp/Tracker (3.7.0):
-    - GrowingAnalytics/DefaultServices (= 3.7.0)
-    - GrowingAnalytics/MobileDebugger (= 3.7.0)
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/Advert (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/APM (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics-cdp/Autotracker (3.7.1):
+    - GrowingAnalytics/AutotrackerCore (= 3.7.1)
+    - GrowingAnalytics/DefaultServices (= 3.7.1)
+    - GrowingAnalytics/Hybrid (= 3.7.1)
+    - GrowingAnalytics/MobileDebugger (= 3.7.1)
+    - GrowingAnalytics/WebCircle (= 3.7.1)
+  - GrowingAnalytics-cdp/Tracker (3.7.1):
+    - GrowingAnalytics/DefaultServices (= 3.7.1)
+    - GrowingAnalytics/MobileDebugger (= 3.7.1)
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/Advert (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/APM (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
     - GrowingAPM/Core
-  - GrowingAnalytics/Autotracker (3.7.0):
-    - GrowingAnalytics/AutotrackerCore (= 3.7.0)
-    - GrowingAnalytics/DefaultServices (= 3.7.0)
-    - GrowingAnalytics/Hybrid (= 3.7.0)
-    - GrowingAnalytics/MobileDebugger (= 3.7.0)
-    - GrowingAnalytics/WebCircle (= 3.7.0)
-  - GrowingAnalytics/AutotrackerCore (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/Autotracker (3.7.1):
+    - GrowingAnalytics/AutotrackerCore (= 3.7.1)
+    - GrowingAnalytics/DefaultServices (= 3.7.1)
+    - GrowingAnalytics/Hybrid (= 3.7.1)
+    - GrowingAnalytics/MobileDebugger (= 3.7.1)
+    - GrowingAnalytics/WebCircle (= 3.7.1)
+  - GrowingAnalytics/AutotrackerCore (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
     - GrowingUtils/AutotrackerCore (= 0.0.7)
-  - GrowingAnalytics/Compression (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/Database (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/DefaultServices (3.7.0):
-    - GrowingAnalytics/Compression (= 3.7.0)
-    - GrowingAnalytics/Database (= 3.7.0)
-    - GrowingAnalytics/Encryption (= 3.7.0)
-    - GrowingAnalytics/Network (= 3.7.0)
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/Encryption (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/Hybrid (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/MobileDebugger (3.7.0):
-    - GrowingAnalytics/Screenshot (= 3.7.0)
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-    - GrowingAnalytics/WebSocket (= 3.7.0)
-  - GrowingAnalytics/Network (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/Protobuf (3.7.0):
-    - GrowingAnalytics/Database (= 3.7.0)
-    - GrowingAnalytics/Protobuf/Proto (= 3.7.0)
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/Protobuf/Proto (3.7.0):
-    - GrowingAnalytics/Database (= 3.7.0)
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/Compression (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/Database (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/DefaultServices (3.7.1):
+    - GrowingAnalytics/Compression (= 3.7.1)
+    - GrowingAnalytics/Database (= 3.7.1)
+    - GrowingAnalytics/Encryption (= 3.7.1)
+    - GrowingAnalytics/Network (= 3.7.1)
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/Encryption (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/Hybrid (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/MobileDebugger (3.7.1):
+    - GrowingAnalytics/Screenshot (= 3.7.1)
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+    - GrowingAnalytics/WebSocket (= 3.7.1)
+  - GrowingAnalytics/Network (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/Protobuf (3.7.1):
+    - GrowingAnalytics/Database (= 3.7.1)
+    - GrowingAnalytics/Protobuf/Proto (= 3.7.1)
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/Protobuf/Proto (3.7.1):
+    - GrowingAnalytics/Database (= 3.7.1)
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
     - Protobuf
-  - GrowingAnalytics/Screenshot (3.7.0):
+  - GrowingAnalytics/Screenshot (3.7.1):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Tracker (3.7.0):
-    - GrowingAnalytics/DefaultServices (= 3.7.0)
-    - GrowingAnalytics/MobileDebugger (= 3.7.0)
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
-  - GrowingAnalytics/TrackerCore (3.7.0):
+  - GrowingAnalytics/Tracker (3.7.1):
+    - GrowingAnalytics/DefaultServices (= 3.7.1)
+    - GrowingAnalytics/MobileDebugger (= 3.7.1)
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
+  - GrowingAnalytics/TrackerCore (3.7.1):
     - GrowingUtils/TrackerCore (= 0.0.7)
-  - GrowingAnalytics/WebCircle (3.7.0):
-    - GrowingAnalytics/AutotrackerCore (= 3.7.0)
-    - GrowingAnalytics/Hybrid (= 3.7.0)
-    - GrowingAnalytics/Screenshot (= 3.7.0)
-    - GrowingAnalytics/WebSocket (= 3.7.0)
-  - GrowingAnalytics/WebSocket (3.7.0):
-    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/WebCircle (3.7.1):
+    - GrowingAnalytics/AutotrackerCore (= 3.7.1)
+    - GrowingAnalytics/Hybrid (= 3.7.1)
+    - GrowingAnalytics/Screenshot (= 3.7.1)
+    - GrowingAnalytics/WebSocket (= 3.7.1)
+  - GrowingAnalytics/WebSocket (3.7.1):
+    - GrowingAnalytics/TrackerCore (= 3.7.1)
   - GrowingAPM (1.0.0):
     - GrowingAPM/Core (= 1.0.0)
     - GrowingAPM/CrashMonitor (= 1.0.0)
@@ -161,8 +161,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: 8d4a3e0e4d1289c1255cefb1877430a3653b056a
-  GrowingAnalytics-cdp: dfe2fd73b5cc3e931a74ef4a1ef0398590af1a8d
+  GrowingAnalytics: 734101fa51d84f0fbc3e893f3a397965249752a7
+  GrowingAnalytics-cdp: b2a609e471bc4092d507ccb5f5037057e2e44e53
   GrowingAPM: 6750d66ca6876c2c7d22c1c087625bc9ccc3430c
   GrowingToolsKit: 134a78b023c4ab7da51e0a1111e9956a96e42dab
   GrowingUtils: e8ba72794651ade9ad60a71662d11baa08d526c8
@@ -174,4 +174,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 8b74d64200d8437dbd5c21a406bd3513fc0eebd0
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.14.2

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,91 +1,91 @@
 PODS:
-  - GrowingAnalytics-cdp/Autotracker (3.6.0):
-    - GrowingAnalytics/AutotrackerCore (= 3.6.0)
-    - GrowingAnalytics/DefaultServices (= 3.6.0)
-    - GrowingAnalytics/Hybrid (= 3.6.0)
-    - GrowingAnalytics/MobileDebugger (= 3.6.0)
-    - GrowingAnalytics/WebCircle (= 3.6.0)
-  - GrowingAnalytics-cdp/Tracker (3.6.0):
-    - GrowingAnalytics/DefaultServices (= 3.6.0)
-    - GrowingAnalytics/MobileDebugger (= 3.6.0)
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/Advert (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/APM (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
+  - GrowingAnalytics-cdp/Autotracker (3.7.0):
+    - GrowingAnalytics/AutotrackerCore (= 3.7.0)
+    - GrowingAnalytics/DefaultServices (= 3.7.0)
+    - GrowingAnalytics/Hybrid (= 3.7.0)
+    - GrowingAnalytics/MobileDebugger (= 3.7.0)
+    - GrowingAnalytics/WebCircle (= 3.7.0)
+  - GrowingAnalytics-cdp/Tracker (3.7.0):
+    - GrowingAnalytics/DefaultServices (= 3.7.0)
+    - GrowingAnalytics/MobileDebugger (= 3.7.0)
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/Advert (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/APM (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
     - GrowingAPM/Core
-  - GrowingAnalytics/Autotracker (3.6.0):
-    - GrowingAnalytics/AutotrackerCore (= 3.6.0)
-    - GrowingAnalytics/DefaultServices (= 3.6.0)
-    - GrowingAnalytics/Hybrid (= 3.6.0)
-    - GrowingAnalytics/MobileDebugger (= 3.6.0)
-    - GrowingAnalytics/WebCircle (= 3.6.0)
-  - GrowingAnalytics/AutotrackerCore (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
+  - GrowingAnalytics/Autotracker (3.7.0):
+    - GrowingAnalytics/AutotrackerCore (= 3.7.0)
+    - GrowingAnalytics/DefaultServices (= 3.7.0)
+    - GrowingAnalytics/Hybrid (= 3.7.0)
+    - GrowingAnalytics/MobileDebugger (= 3.7.0)
+    - GrowingAnalytics/WebCircle (= 3.7.0)
+  - GrowingAnalytics/AutotrackerCore (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
     - GrowingUtils/AutotrackerCore (= 0.0.7)
-  - GrowingAnalytics/Compression (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/Database (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/DefaultServices (3.6.0):
-    - GrowingAnalytics/Compression (= 3.6.0)
-    - GrowingAnalytics/Database (= 3.6.0)
-    - GrowingAnalytics/Encryption (= 3.6.0)
-    - GrowingAnalytics/Network (= 3.6.0)
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/Encryption (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/Hybrid (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/MobileDebugger (3.6.0):
-    - GrowingAnalytics/Screenshot (= 3.6.0)
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-    - GrowingAnalytics/WebSocket (= 3.6.0)
-  - GrowingAnalytics/Network (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/Protobuf (3.6.0):
-    - GrowingAnalytics/Database (= 3.6.0)
-    - GrowingAnalytics/Protobuf/Proto (= 3.6.0)
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/Protobuf/Proto (3.6.0):
-    - GrowingAnalytics/Database (= 3.6.0)
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
+  - GrowingAnalytics/Compression (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/Database (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/DefaultServices (3.7.0):
+    - GrowingAnalytics/Compression (= 3.7.0)
+    - GrowingAnalytics/Database (= 3.7.0)
+    - GrowingAnalytics/Encryption (= 3.7.0)
+    - GrowingAnalytics/Network (= 3.7.0)
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/Encryption (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/Hybrid (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/MobileDebugger (3.7.0):
+    - GrowingAnalytics/Screenshot (= 3.7.0)
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+    - GrowingAnalytics/WebSocket (= 3.7.0)
+  - GrowingAnalytics/Network (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/Protobuf (3.7.0):
+    - GrowingAnalytics/Database (= 3.7.0)
+    - GrowingAnalytics/Protobuf/Proto (= 3.7.0)
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/Protobuf/Proto (3.7.0):
+    - GrowingAnalytics/Database (= 3.7.0)
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
     - Protobuf
-  - GrowingAnalytics/Screenshot (3.6.0):
+  - GrowingAnalytics/Screenshot (3.7.0):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Tracker (3.6.0):
-    - GrowingAnalytics/DefaultServices (= 3.6.0)
-    - GrowingAnalytics/MobileDebugger (= 3.6.0)
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAnalytics/TrackerCore (3.6.0):
+  - GrowingAnalytics/Tracker (3.7.0):
+    - GrowingAnalytics/DefaultServices (= 3.7.0)
+    - GrowingAnalytics/MobileDebugger (= 3.7.0)
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAnalytics/TrackerCore (3.7.0):
     - GrowingUtils/TrackerCore (= 0.0.7)
-  - GrowingAnalytics/WebCircle (3.6.0):
-    - GrowingAnalytics/AutotrackerCore (= 3.6.0)
-    - GrowingAnalytics/Hybrid (= 3.6.0)
-    - GrowingAnalytics/Screenshot (= 3.6.0)
-    - GrowingAnalytics/WebSocket (= 3.6.0)
-  - GrowingAnalytics/WebSocket (3.6.0):
-    - GrowingAnalytics/TrackerCore (= 3.6.0)
-  - GrowingAPM (0.0.14):
-    - GrowingAPM/Core (= 0.0.14)
-    - GrowingAPM/CrashMonitor (= 0.0.14)
-    - GrowingAPM/UIMonitor (= 0.0.14)
-  - GrowingAPM/Core (0.0.14):
+  - GrowingAnalytics/WebCircle (3.7.0):
+    - GrowingAnalytics/AutotrackerCore (= 3.7.0)
+    - GrowingAnalytics/Hybrid (= 3.7.0)
+    - GrowingAnalytics/Screenshot (= 3.7.0)
+    - GrowingAnalytics/WebSocket (= 3.7.0)
+  - GrowingAnalytics/WebSocket (3.7.0):
+    - GrowingAnalytics/TrackerCore (= 3.7.0)
+  - GrowingAPM (1.0.0):
+    - GrowingAPM/Core (= 1.0.0)
+    - GrowingAPM/CrashMonitor (= 1.0.0)
+    - GrowingAPM/UIMonitor (= 1.0.0)
+  - GrowingAPM/Core (1.0.0):
     - GrowingUtils/TrackerCore
-  - GrowingAPM/CrashMonitor (0.0.14):
+  - GrowingAPM/CrashMonitor (1.0.0):
     - GrowingAPM/Core
-  - GrowingAPM/UIMonitor (0.0.14):
+  - GrowingAPM/UIMonitor (1.0.0):
     - GrowingAPM/Core
-  - GrowingToolsKit (1.2.0):
-    - GrowingToolsKit/Default (= 1.2.0)
-  - GrowingToolsKit/APMCore (1.2.0):
+  - GrowingToolsKit (1.2.1):
+    - GrowingToolsKit/Default (= 1.2.1)
+  - GrowingToolsKit/APMCore (1.2.1):
     - GrowingAPM/Core
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Core (1.2.0)
-  - GrowingToolsKit/CrashMonitor (1.2.0):
+  - GrowingToolsKit/Core (1.2.1)
+  - GrowingToolsKit/CrashMonitor (1.2.1):
     - GrowingAPM/CrashMonitor
     - GrowingToolsKit/APMCore
-  - GrowingToolsKit/Default (1.2.0):
+  - GrowingToolsKit/Default (1.2.1):
     - GrowingToolsKit/Core
     - GrowingToolsKit/CrashMonitor
     - GrowingToolsKit/EventsList
@@ -95,20 +95,20 @@ PODS:
     - GrowingToolsKit/SDKInfo
     - GrowingToolsKit/Settings
     - GrowingToolsKit/XPathTrack
-  - GrowingToolsKit/EventsList (1.2.0):
+  - GrowingToolsKit/EventsList (1.2.1):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/LaunchTime (1.2.0):
+  - GrowingToolsKit/LaunchTime (1.2.1):
     - GrowingAPM/UIMonitor
     - GrowingToolsKit/APMCore
-  - GrowingToolsKit/NetFlow (1.2.0):
+  - GrowingToolsKit/NetFlow (1.2.1):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Realtime (1.2.0):
+  - GrowingToolsKit/Realtime (1.2.1):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/SDKInfo (1.2.0):
+  - GrowingToolsKit/SDKInfo (1.2.1):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Settings (1.2.0):
+  - GrowingToolsKit/Settings (1.2.1):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/XPathTrack (1.2.0):
+  - GrowingToolsKit/XPathTrack (1.2.1):
     - GrowingToolsKit/Core
   - GrowingUtils/AutotrackerCore (0.0.7):
     - GrowingUtils/TrackerCore
@@ -121,12 +121,12 @@ PODS:
   - LBXScan/Types (2.3)
   - LBXScan/UI (2.3):
     - LBXScan/Types (~> 2.2)
-  - Protobuf (3.24.3)
+  - Protobuf (3.24.4)
   - SDCycleScrollView (1.82):
     - SDWebImage (>= 5.0.0)
-  - SDWebImage (5.18.1):
-    - SDWebImage/Core (= 5.18.1)
-  - SDWebImage/Core (5.18.1)
+  - SDWebImage (5.18.3):
+    - SDWebImage/Core (= 5.18.3)
+  - SDWebImage/Core (5.18.3)
 
 DEPENDENCIES:
   - GrowingAnalytics-cdp/Autotracker (from `../`)
@@ -161,17 +161,17 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: 184d771cd73537db523f669ad037e1bcd0a3e33b
-  GrowingAnalytics-cdp: 46c87f38b8561465c243f9302fb1c8bc45697be6
-  GrowingAPM: 79fe4f4a12d94432fa4a552d56c41940ea13961a
-  GrowingToolsKit: 9c0d6e41c9678397dbaa3304b1738a2867b023ae
+  GrowingAnalytics: 8d4a3e0e4d1289c1255cefb1877430a3653b056a
+  GrowingAnalytics-cdp: dfe2fd73b5cc3e931a74ef4a1ef0398590af1a8d
+  GrowingAPM: 6750d66ca6876c2c7d22c1c087625bc9ccc3430c
+  GrowingToolsKit: 134a78b023c4ab7da51e0a1111e9956a96e42dab
   GrowingUtils: e8ba72794651ade9ad60a71662d11baa08d526c8
   KIF: 7660c626b0f2d4562533590960db70a36d640558
   LBXScan: e51449f0832d1fe17da632af0d22adeb3cfa3543
-  Protobuf: 970f7ee93a3a08e3cf64859b8efd95ee32b4f87f
+  Protobuf: 351e9022fe13a6e2af00e9aefc22077cb88520f8
   SDCycleScrollView: a0d74c3384caa72bdfc81470bdbc8c14b3e1fbcf
-  SDWebImage: ebdbcebc7933a45226d9313bd0118bc052ad458b
+  SDWebImage: 96e0c18ef14010b7485210e92fac888587ebb958
 
-PODFILE CHECKSUM: 81da6e462af8169c5f556b95bac2c3f1f2d91b2a
+PODFILE CHECKSUM: 8b74d64200d8437dbd5c21a406bd3513fc0eebd0
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/GrowingAnalytics-cdp.podspec
+++ b/GrowingAnalytics-cdp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics-cdp'
-  s.version          = '3.7.0'
+  s.version          = '3.7.1-beta.1'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics-cdp基于GrowingAnalytics，同样具备自动采集基本的用户行为事件，比如访问和行为数据等。

--- a/GrowingAnalytics-cdp.podspec
+++ b/GrowingAnalytics-cdp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics-cdp'
-  s.version          = '3.7.1-beta.1'
+  s.version          = '3.7.1'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics-cdp基于GrowingAnalytics，同样具备自动采集基本的用户行为事件，比如访问和行为数据等。

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.7.1-beta.1'
+  s.version          = '3.7.1'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.7.0'
+  s.version          = '3.7.1-beta.1'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/GrowingAutotracker-cdp/GrowingAutotracker.h
+++ b/GrowingAutotracker-cdp/GrowingAutotracker.h
@@ -17,10 +17,14 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#import <UIKit/UIKit.h>
+@import UIKit;
+#if __has_include(<GrowingAnalytics/GrowingTrackConfiguration.h>) // Cocoapods or Manual
+@import GrowingAnalytics;
+#else
 #import "GrowingAttributesBuilder.h"
 #import "GrowingAutotrackConfiguration.h"
 #import "GrowingDynamicProxy.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GrowingTracker-cdp/GrowingTracker.h
+++ b/GrowingTracker-cdp/GrowingTracker.h
@@ -17,9 +17,13 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#if __has_include(<GrowingAnalytics/GrowingTrackConfiguration.h>) // Cocoapods or Manual
+@import GrowingAnalytics;
+#else
 #import "GrowingAttributesBuilder.h"
-#import "GrowingDynamicProxy.h"
 #import "GrowingTrackConfiguration.h"
+#import "GrowingDynamicProxy.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -38,7 +38,7 @@
 #import "GrowingTrackerCore/Utils/GrowingDeviceInfo.h"
 #import "GrowingULAppLifecycle.h"
 
-NSString *const GrowingTrackerVersionName = @"3.7.1-beta.1";
+NSString *const GrowingTrackerVersionName = @"3.7.1";
 const int GrowingTrackerVersionCode = 30701;
 
 @interface GrowingRealTracker ()

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -38,8 +38,8 @@
 #import "GrowingTrackerCore/Utils/GrowingDeviceInfo.h"
 #import "GrowingULAppLifecycle.h"
 
-NSString *const GrowingTrackerVersionName = @"3.7.0";
-const int GrowingTrackerVersionCode = 30700;
+NSString *const GrowingTrackerVersionName = @"3.7.1-beta.1";
+const int GrowingTrackerVersionCode = 30701;
 
 @interface GrowingRealTracker ()
 

--- a/GrowingTrackerCore/Helpers/Foundation/NSURL+GrowingHelper.m
+++ b/GrowingTrackerCore/Helpers/Foundation/NSURL+GrowingHelper.m
@@ -29,7 +29,7 @@
         NSArray *kv = [pair componentsSeparatedByString:@"="];
         if (kv.count == 2) {
             NSString *key = [kv objectAtIndex:0];
-            NSString *val = [[kv objectAtIndex:1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            NSString *val = [[kv objectAtIndex:1] stringByRemovingPercentEncoding];
             if (val) {
                 [params setObject:val forKey:key];
             }

--- a/scripts/cocoapods-beta.sh
+++ b/scripts/cocoapods-beta.sh
@@ -31,5 +31,5 @@ echo y | pod trunk delete GrowingAnalytics-cdp $POD_BETA_VERSOIN
 git tag $POD_BETA_VERSOIN
 git push --tags
 
-pod trunk push GrowingAnalytics.podspec --allow-warnings --use-libraries
-pod trunk push GrowingAnalytics-cdp.podspec --allow-warnings --use-libraries --synchronous
+pod trunk push GrowingAnalytics.podspec --allow-warnings
+pod trunk push GrowingAnalytics-cdp.podspec --allow-warnings --synchronous


### PR DESCRIPTION
问题：**Swift 项目**，如需使用 Cocoapods 集成 SDK 3.3.5 版本及以上，会出现 Include of non-modular header inside framework module 报错，请参考 [解决方案](https://growingio.github.io/growingio-sdk-docs-v3/docs/ios/Introduce#include-of-non-modular-header-inside-framework-module-%E6%8A%A5%E9%94%99%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88)

此 PR 解决以上问题，不再需要用户去修改
* 同时兼容了 SPM、Cocoapods、Manual
* SDK 4.x 无此问题
* 不合并，作为 3.7.1 分支

前情提要
* #251 