### PR TITLE
feat(autotrack): autotrack-page white list

### DIFF
--- a/GrowingAutotrackerCore/GrowingAutotrackConfiguration.m
+++ b/GrowingAutotrackerCore/GrowingAutotrackConfiguration.m
@@ -34,6 +34,8 @@
     if (self = [super initWithAccountId:accountId]) {
         _autotrackEnabled = YES;
         _impressionScale = 0.0f;
+        _autotrackAllPages = NO;
+        _autotrackPagesWhiteList = nil;
         GROWING_LOCK_INIT(lock);
         _ignoreViewClasses = [NSMutableSet set];
     }
@@ -45,6 +47,8 @@
     GrowingAutotrackConfiguration *configuration = (GrowingAutotrackConfiguration *)[super copyWithZone:zone];
     configuration->_autotrackEnabled = _autotrackEnabled;
     configuration->_impressionScale = _impressionScale;
+    configuration->_autotrackAllPages = _autotrackAllPages;
+    configuration->_autotrackPagesWhiteList = [_autotrackPagesWhiteList copy];
     configuration->_ignoreViewClasses = _ignoreViewClasses;
     return configuration;
 }

--- a/GrowingAutotrackerCore/Page/GrowingPageManager.m
+++ b/GrowingAutotrackerCore/Page/GrowingPageManager.m
@@ -18,17 +18,17 @@
 //  limitations under the License.
 
 #import "GrowingAutotrackerCore/Page/GrowingPageManager.h"
+#import "GrowingAutotrackConfiguration.h"
 #import "GrowingAutotrackerCore/Autotrack/UIViewController+GrowingAutotracker.h"
 #import "GrowingAutotrackerCore/GrowingNode/Category/UIViewController+GrowingNode.h"
 #import "GrowingTrackerCore/Event/Autotrack/GrowingPageEvent.h"
 #import "GrowingTrackerCore/Event/GrowingEventManager.h"
 #import "GrowingTrackerCore/Helpers/GrowingHelpers.h"
+#import "GrowingTrackerCore/Manager/GrowingConfigurationManager.h"
 #import "GrowingTrackerCore/Thirdparty/Logger/GrowingLogger.h"
 #import "GrowingTrackerCore/Utils/GrowingArgumentChecker.h"
 #import "GrowingULAppLifecycle.h"
 #import "GrowingULViewControllerLifecycle.h"
-#import "GrowingTrackerCore/Manager/GrowingConfigurationManager.h"
-#import "GrowingAutotrackConfiguration.h"
 
 @interface GrowingPageManager () <GrowingULViewControllerLifecycleDelegate>
 
@@ -89,7 +89,7 @@
     GrowingPage *page = [controller growingPageObject];
     if (!page) {
         page = [self createdPage:controller];
-        
+
         // 首次进入该controller，获取初始化autotrackPage配置
         GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
         if ([configuration isKindOfClass:[GrowingAutotrackConfiguration class]]) {

--- a/GrowingAutotrackerCore/Page/GrowingPageManager.m
+++ b/GrowingAutotrackerCore/Page/GrowingPageManager.m
@@ -27,6 +27,8 @@
 #import "GrowingTrackerCore/Utils/GrowingArgumentChecker.h"
 #import "GrowingULAppLifecycle.h"
 #import "GrowingULViewControllerLifecycle.h"
+#import "GrowingTrackerCore/Manager/GrowingConfigurationManager.h"
+#import "GrowingAutotrackConfiguration.h"
 
 @interface GrowingPageManager () <GrowingULViewControllerLifecycleDelegate>
 
@@ -87,6 +89,18 @@
     GrowingPage *page = [controller growingPageObject];
     if (!page) {
         page = [self createdPage:controller];
+        
+        // 首次进入该controller，获取初始化autotrackPage配置
+        GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
+        if ([configuration isKindOfClass:[GrowingAutotrackConfiguration class]]) {
+            GrowingAutotrackConfiguration *autotrackConfiguration = (GrowingAutotrackConfiguration *)configuration;
+            NSString *controllerClass = NSStringFromClass([controller class]);
+            if (autotrackConfiguration.autotrackAllPages) {
+                controller.growingPageAlias = controllerClass;
+            } else if (autotrackConfiguration.autotrackPagesWhiteList != nil) {
+                controller.growingPageAlias = autotrackConfiguration.autotrackPagesWhiteList[controllerClass];
+            }
+        }
     } else {
         [page refreshShowTimestamp];
     }

--- a/GrowingAutotrackerCore/Page/GrowingPageManager.m
+++ b/GrowingAutotrackerCore/Page/GrowingPageManager.m
@@ -90,15 +90,17 @@
     if (!page) {
         page = [self createdPage:controller];
 
-        // 首次进入该controller，获取初始化autotrackPage配置
-        GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
-        if ([configuration isKindOfClass:[GrowingAutotrackConfiguration class]]) {
-            GrowingAutotrackConfiguration *autotrackConfiguration = (GrowingAutotrackConfiguration *)configuration;
-            NSString *controllerClass = NSStringFromClass([controller class]);
-            if (autotrackConfiguration.autotrackAllPages) {
-                controller.growingPageAlias = controllerClass;
-            } else if (autotrackConfiguration.autotrackPagesWhiteList != nil) {
-                controller.growingPageAlias = autotrackConfiguration.autotrackPagesWhiteList[controllerClass];
+        if (!page.isAutotrack) {
+            // 首次进入该controller，获取初始化autotrackPage配置
+            GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
+            if ([configuration isKindOfClass:[GrowingAutotrackConfiguration class]]) {
+                GrowingAutotrackConfiguration *autotrackConfiguration = (GrowingAutotrackConfiguration *)configuration;
+                NSString *controllerClass = NSStringFromClass([controller class]);
+                if (autotrackConfiguration.autotrackAllPages) {
+                    controller.growingPageAlias = controllerClass;
+                } else if (autotrackConfiguration.autotrackPagesWhiteList != nil) {
+                    controller.growingPageAlias = autotrackConfiguration.autotrackPagesWhiteList[controllerClass];
+                }
             }
         }
     } else {

--- a/GrowingAutotrackerCore/Public/GrowingAutotrackConfiguration.h
+++ b/GrowingAutotrackerCore/Public/GrowingAutotrackConfiguration.h
@@ -32,6 +32,8 @@ typedef NS_ENUM(NSUInteger, GrowingIgnorePolicy) {
 
 @property (nonatomic, assign) BOOL autotrackEnabled;
 @property (nonatomic, assign) float impressionScale;
+@property (nonatomic, assign) BOOL autotrackAllPages;
+@property (nonatomic, copy) NSDictionary<NSString *, NSString *> *autotrackPagesWhiteList;
 
 @end
 

--- a/Modules/ImpressionTrack/GrowingImpressionTrack.m
+++ b/Modules/ImpressionTrack/GrowingImpressionTrack.m
@@ -18,17 +18,17 @@
 //  limitations under the License.
 
 #import "Modules/ImpressionTrack/GrowingImpressionTrack.h"
+#import "GrowingAutotrackConfiguration.h"
 #import "GrowingAutotrackerCore/GrowingNode/Category/UIView+GrowingNode.h"
 #import "GrowingTrackerCore/Event/GrowingEventGenerator.h"
-#import "GrowingTrackerCore/Thirdparty/Logger/GrowingLogger.h"
 #import "GrowingTrackerCore/Manager/GrowingConfigurationManager.h"
+#import "GrowingTrackerCore/Thirdparty/Logger/GrowingLogger.h"
 #import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
 #import "GrowingULAppLifecycle.h"
 #import "GrowingULApplication.h"
 #import "GrowingULSwizzle.h"
 #import "GrowingULViewControllerLifecycle.h"
 #import "Modules/ImpressionTrack/UIView+GrowingImpressionInternal.h"
-#import "GrowingAutotrackConfiguration.h"
 
 GrowingMod(GrowingImpressionTrack)
 

--- a/Modules/ImpressionTrack/GrowingImpressionTrack.m
+++ b/Modules/ImpressionTrack/GrowingImpressionTrack.m
@@ -21,12 +21,14 @@
 #import "GrowingAutotrackerCore/GrowingNode/Category/UIView+GrowingNode.h"
 #import "GrowingTrackerCore/Event/GrowingEventGenerator.h"
 #import "GrowingTrackerCore/Thirdparty/Logger/GrowingLogger.h"
+#import "GrowingTrackerCore/Manager/GrowingConfigurationManager.h"
 #import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
 #import "GrowingULAppLifecycle.h"
 #import "GrowingULApplication.h"
 #import "GrowingULSwizzle.h"
 #import "GrowingULViewControllerLifecycle.h"
 #import "Modules/ImpressionTrack/UIView+GrowingImpressionInternal.h"
+#import "GrowingAutotrackConfiguration.h"
 
 GrowingMod(GrowingImpressionTrack)
 
@@ -46,6 +48,13 @@ static BOOL isInResignSate;
 }
 
 - (void)growingModInit:(GrowingContext *)context {
+    GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
+    if ([configuration isKindOfClass:[GrowingAutotrackConfiguration class]]) {
+        GrowingAutotrackConfiguration *autotrackConfiguration = (GrowingAutotrackConfiguration *)configuration;
+        if (!autotrackConfiguration.autotrackEnabled) {
+            return;
+        }
+    }
     if ([GrowingULApplication isAppExtension]) {
         return;
     }


### PR DESCRIPTION
## PR 内容
* fix(imp): disable impressionTrack module when autotrackEnabled is false
* feat: autotrack-page white list

---

* fix(imp): 当 autotrackEnabled 配置为 false 时，禁用 impressionTrack 模块
* feat: 增加 autotrackPage 白名单配置，其中：
  * 当 autotrackAllPages 配置为 true 时，默认所有 viewController 都会追踪，别名为对应的 className
  * 配置 autotrackPagesWhiteList (key 为 viewController 对应的 className，value 配置别名)，key 对应的 viewController 会追踪

## 测试步骤
 * 通过 autotrackAllPages、autotrackPagesWhiteList 进行初始化配置验证
 * 测试在 autotrackEnabled = false 时，impressionTrack 模块是否还能正常运行

## 其他
优先级：autotrackPage:alias:attributes: 接口 > autotrackAllPages > autotrackPagesWhiteList