### PR TITLE
fix(autotrack): autotrackAllPages logic

### DIFF
--- a/GrowingAutotrackerCore/Page/GrowingPageManager.m
+++ b/GrowingAutotrackerCore/Page/GrowingPageManager.m
@@ -56,6 +56,22 @@
     });
 }
 
+- (void)viewControllerDidLoad:(UIViewController *)controller {
+    if (controller.growingPageAlias == nil /* !page.isAutotrack */) {
+        // 首次进入该controller，获取初始化autotrackPage配置
+        GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
+        if ([configuration isKindOfClass:[GrowingAutotrackConfiguration class]]) {
+            GrowingAutotrackConfiguration *autotrackConfiguration = (GrowingAutotrackConfiguration *)configuration;
+            NSString *controllerClass = NSStringFromClass([controller class]);
+            if (autotrackConfiguration.autotrackAllPages) {
+                controller.growingPageAlias = controllerClass;
+            } else if (autotrackConfiguration.autotrackPagesWhiteList != nil) {
+                controller.growingPageAlias = autotrackConfiguration.autotrackPagesWhiteList[controllerClass];
+            }
+        }
+    }
+}
+
 - (void)viewControllerDidAppear:(UIViewController *)controller {
     if (![self isPrivateViewController:controller]) {
         GrowingPage *page = [self createdViewControllerPage:controller];
@@ -89,20 +105,6 @@
     GrowingPage *page = [controller growingPageObject];
     if (!page) {
         page = [self createdPage:controller];
-
-        if (!page.isAutotrack) {
-            // 首次进入该controller，获取初始化autotrackPage配置
-            GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
-            if ([configuration isKindOfClass:[GrowingAutotrackConfiguration class]]) {
-                GrowingAutotrackConfiguration *autotrackConfiguration = (GrowingAutotrackConfiguration *)configuration;
-                NSString *controllerClass = NSStringFromClass([controller class]);
-                if (autotrackConfiguration.autotrackAllPages) {
-                    controller.growingPageAlias = controllerClass;
-                } else if (autotrackConfiguration.autotrackPagesWhiteList != nil) {
-                    controller.growingPageAlias = autotrackConfiguration.autotrackPagesWhiteList[controllerClass];
-                }
-            }
-        }
     } else {
         [page refreshShowTimestamp];
     }


### PR DESCRIPTION
### PR 内容

适配 GioKit 2.0.1 的改动，以正常忽略 GioKit 的页面
https://github.com/growingio/growingio-sdk-ios-toolskit/commit/c6f3d003b59cacfd5406be48d67feb1dff96a27e

### 测试步骤

通过 autotrackAllPages、autotrackPagesWhiteList 进行初始化配置验证

### 其他
#301 