### PR TITLE
fix: add limit of events data length when query from db

### DIFF
--- a/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests.m
+++ b/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests.m
@@ -125,7 +125,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, NO);
     XCTAssertEqualObjects(configuration.urlScheme, nil);
     XCTAssertEqual(configuration.encryptEnabled, NO);
-    XCTAssertEqual(configuration.compressEnabled, YES);
+    XCTAssertEqual(configuration.compressEnabled, NO);
     XCTAssertEqual(configuration.impressionScale, 0);
     XCTAssertEqualObjects(configuration.dataSourceId, nil);
     XCTAssertEqualObjects(configuration.networkConfig, nil);
@@ -145,7 +145,7 @@
     config.idMappingEnabled = YES;
     config.urlScheme = @"growing.autotracker";
     config.encryptEnabled = YES;
-    config.compressEnabled = NO;
+    config.compressEnabled = YES;
     config.impressionScale = 0.5;
     config.dataSourceId = @"12345";
     GrowingNetworkConfig *networkConfig = [GrowingNetworkConfig config];
@@ -167,7 +167,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, YES);
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.autotracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
-    XCTAssertEqual(configuration.compressEnabled, NO);
+    XCTAssertEqual(configuration.compressEnabled, YES);
     XCTAssertEqual(configuration.impressionScale, 0.5);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
     XCTAssertNotNil(configuration.networkConfig);
@@ -191,7 +191,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, NO);
     XCTAssertEqualObjects(configuration.urlScheme, nil);
     XCTAssertEqual(configuration.encryptEnabled, NO);
-    XCTAssertEqual(configuration.compressEnabled, YES);
+    XCTAssertEqual(configuration.compressEnabled, NO);
     XCTAssertEqualObjects(configuration.dataSourceId, nil);
     XCTAssertEqualObjects(configuration.networkConfig, nil);
 }
@@ -210,7 +210,7 @@
     config.idMappingEnabled = YES;
     config.urlScheme = @"growing.tracker";
     config.encryptEnabled = YES;
-    config.compressEnabled = NO;
+    config.compressEnabled = YES;
     config.dataSourceId = @"12345";
     GrowingNetworkConfig *networkConfig = [GrowingNetworkConfig config];
     networkConfig.requestTimeout = 0.3f;
@@ -230,7 +230,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, YES);
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.tracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
-    XCTAssertEqual(configuration.compressEnabled, NO);
+    XCTAssertEqual(configuration.compressEnabled, YES);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
     XCTAssertNotNil(configuration.networkConfig);
     XCTAssertEqual(configuration.networkConfig.requestTimeout, 0.3f);

--- a/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests.m
+++ b/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests.m
@@ -125,6 +125,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, NO);
     XCTAssertEqualObjects(configuration.urlScheme, nil);
     XCTAssertEqual(configuration.encryptEnabled, NO);
+    XCTAssertEqual(configuration.compressEnabled, YES);
     XCTAssertEqual(configuration.impressionScale, 0);
     XCTAssertEqualObjects(configuration.dataSourceId, nil);
     XCTAssertEqualObjects(configuration.networkConfig, nil);
@@ -144,6 +145,7 @@
     config.idMappingEnabled = YES;
     config.urlScheme = @"growing.autotracker";
     config.encryptEnabled = YES;
+    config.compressEnabled = NO;
     config.impressionScale = 0.5;
     config.dataSourceId = @"12345";
     GrowingNetworkConfig *networkConfig = [GrowingNetworkConfig config];
@@ -165,6 +167,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, YES);
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.autotracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
+    XCTAssertEqual(configuration.compressEnabled, NO);
     XCTAssertEqual(configuration.impressionScale, 0.5);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
     XCTAssertNotNil(configuration.networkConfig);
@@ -188,6 +191,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, NO);
     XCTAssertEqualObjects(configuration.urlScheme, nil);
     XCTAssertEqual(configuration.encryptEnabled, NO);
+    XCTAssertEqual(configuration.compressEnabled, YES);
     XCTAssertEqualObjects(configuration.dataSourceId, nil);
     XCTAssertEqualObjects(configuration.networkConfig, nil);
 }
@@ -206,6 +210,7 @@
     config.idMappingEnabled = YES;
     config.urlScheme = @"growing.tracker";
     config.encryptEnabled = YES;
+    config.compressEnabled = NO;
     config.dataSourceId = @"12345";
     GrowingNetworkConfig *networkConfig = [GrowingNetworkConfig config];
     networkConfig.requestTimeout = 0.3f;
@@ -225,6 +230,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, YES);
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.tracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
+    XCTAssertEqual(configuration.compressEnabled, NO);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
     XCTAssertNotNil(configuration.networkConfig);
     XCTAssertEqual(configuration.networkConfig.requestTimeout, 0.3f);

--- a/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests2.m
+++ b/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests2.m
@@ -61,7 +61,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, NO);
     XCTAssertEqualObjects(configuration.urlScheme, nil);
     XCTAssertEqual(configuration.encryptEnabled, NO);
-    XCTAssertEqual(configuration.compressEnabled, YES);
+    XCTAssertEqual(configuration.compressEnabled, NO);
     XCTAssertEqual(configuration.impressionScale, 0);
     XCTAssertEqualObjects(configuration.dataSourceId, nil);
 }
@@ -80,7 +80,7 @@
     config.idMappingEnabled = YES;
     config.urlScheme = @"growing.autotracker";
     config.encryptEnabled = YES;
-    config.compressEnabled = NO;
+    config.compressEnabled = YES;
     config.impressionScale = 0.5;
     config.dataSourceId = @"12345";
     [GrowingRealAutotracker trackerWithConfiguration:config launchOptions:nil];
@@ -99,7 +99,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, YES);
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.autotracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
-    XCTAssertEqual(configuration.compressEnabled, NO);
+    XCTAssertEqual(configuration.compressEnabled, YES);
     XCTAssertEqual(configuration.impressionScale, 0.5);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
 }
@@ -121,7 +121,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, NO);
     XCTAssertEqualObjects(configuration.urlScheme, nil);
     XCTAssertEqual(configuration.encryptEnabled, NO);
-    XCTAssertEqual(configuration.compressEnabled, YES);
+    XCTAssertEqual(configuration.compressEnabled, NO);
     XCTAssertEqualObjects(configuration.dataSourceId, nil);
 }
 
@@ -139,7 +139,7 @@
     config.idMappingEnabled = YES;
     config.urlScheme = @"growing.tracker";
     config.encryptEnabled = YES;
-    config.compressEnabled = NO;
+    config.compressEnabled = YES;
     config.dataSourceId = @"12345";
     [GrowingRealTracker trackerWithConfiguration:config launchOptions:nil];
 
@@ -156,7 +156,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, YES);
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.tracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
-    XCTAssertEqual(configuration.compressEnabled, NO);
+    XCTAssertEqual(configuration.compressEnabled, YES);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
 }
 

--- a/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests2.m
+++ b/Example/GrowingAnalyticsTests/GrowingAnalyticsStartTests/GrowingAnalyticsStartTests2.m
@@ -61,6 +61,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, NO);
     XCTAssertEqualObjects(configuration.urlScheme, nil);
     XCTAssertEqual(configuration.encryptEnabled, NO);
+    XCTAssertEqual(configuration.compressEnabled, YES);
     XCTAssertEqual(configuration.impressionScale, 0);
     XCTAssertEqualObjects(configuration.dataSourceId, nil);
 }
@@ -79,6 +80,7 @@
     config.idMappingEnabled = YES;
     config.urlScheme = @"growing.autotracker";
     config.encryptEnabled = YES;
+    config.compressEnabled = NO;
     config.impressionScale = 0.5;
     config.dataSourceId = @"12345";
     [GrowingRealAutotracker trackerWithConfiguration:config launchOptions:nil];
@@ -97,6 +99,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, YES);
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.autotracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
+    XCTAssertEqual(configuration.compressEnabled, NO);
     XCTAssertEqual(configuration.impressionScale, 0.5);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
 }
@@ -118,6 +121,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, NO);
     XCTAssertEqualObjects(configuration.urlScheme, nil);
     XCTAssertEqual(configuration.encryptEnabled, NO);
+    XCTAssertEqual(configuration.compressEnabled, YES);
     XCTAssertEqualObjects(configuration.dataSourceId, nil);
 }
 
@@ -135,6 +139,7 @@
     config.idMappingEnabled = YES;
     config.urlScheme = @"growing.tracker";
     config.encryptEnabled = YES;
+    config.compressEnabled = NO;
     config.dataSourceId = @"12345";
     [GrowingRealTracker trackerWithConfiguration:config launchOptions:nil];
 
@@ -151,6 +156,7 @@
     XCTAssertEqual(configuration.idMappingEnabled, YES);
     XCTAssertEqualObjects(configuration.urlScheme, @"growing.tracker");
     XCTAssertEqual(configuration.encryptEnabled, YES);
+    XCTAssertEqual(configuration.compressEnabled, NO);
     XCTAssertEqualObjects(configuration.dataSourceId, @"12345");
 }
 

--- a/Example/GrowingAnalyticsTests/ModulesTests/ProtobufTests/ProtobufDatabaseTest.m
+++ b/Example/GrowingAnalyticsTests/ModulesTests/ProtobufTests/ProtobufDatabaseTest.m
@@ -95,7 +95,7 @@
     // insert events
     XCTAssertEqual([database insertEvents:events], YES);
 
-    NSArray *array2 = [database getEventsByCount:insertCount policy:GrowingEventSendPolicyInstant];
+    NSArray *array2 = [database getEventsByCount:insertCount limitSize:1000000 policy:GrowingEventSendPolicyInstant];
     XCTAssertEqual(array2.count, insertCount);
 
     // delete events
@@ -157,6 +157,7 @@
     NSInteger insertCount = 1;
     NSArray *array = [database
         getEventsByCount:5
+                      limitSize:1000000
                   policy:GrowingEventSendPolicyInstant | GrowingEventSendPolicyMobileData |
                          GrowingEventSendPolicyWiFi];  // 避免多线程情况下，刚好还有其他事件产生入库，这里数值设定大一点
     XCTAssertGreaterThanOrEqual(array.count, insertCount);

--- a/Example/GrowingAnalyticsTests/ServicesTests/DatabaseTests/JSONDatabaseTest.m
+++ b/Example/GrowingAnalyticsTests/ServicesTests/DatabaseTests/JSONDatabaseTest.m
@@ -90,7 +90,7 @@
     // insert events
     XCTAssertEqual([database insertEvents:events], YES);
 
-    NSArray *array2 = [database getEventsByCount:insertCount policy:GrowingEventSendPolicyInstant];
+    NSArray *array2 = [database getEventsByCount:insertCount limitSize:1000000 policy:GrowingEventSendPolicyInstant];
     XCTAssertEqual(array2.count, insertCount);
 
     // delete events
@@ -151,6 +151,7 @@
     NSInteger insertCount = 1;
     NSArray *array = [database
         getEventsByCount:5
+                      limitSize:1000000
                   policy:GrowingEventSendPolicyInstant | GrowingEventSendPolicyMobileData |
                          GrowingEventSendPolicyWiFi];  // 避免多线程情况下，刚好还有其他事件产生入库，这里数值设定大一点
     XCTAssertGreaterThanOrEqual(array.count, insertCount);

--- a/Example/GrowingAnalyticsTests/TrackerCoreTests/DatabaseTests/DatabaseTest.m
+++ b/Example/GrowingAnalyticsTests/TrackerCoreTests/DatabaseTests/DatabaseTest.m
@@ -82,7 +82,7 @@
     {
         XCTAssertTrue([self.database clearAllItems]);
         XCTAssertEqual(self.database.countOfEvents, 0);
-        NSArray *events2 = [self.database getEventsByCount:1 policy:GrowingEventSendPolicyInstant];
+        NSArray *events2 = [self.database getEventsByCount:1 limitSize:1000000 policy:GrowingEventSendPolicyInstant];
         XCTAssertEqual(events2.count, 0);
     }
 
@@ -96,7 +96,7 @@
                                                    sdkVersion:self.event.sdkVersion];
         XCTAssertNoThrow([self.database setEvent:event forKey:uuid]);
         XCTAssertEqual(self.database.countOfEvents, 1);
-        NSArray *events = [self.database getEventsByCount:1 policy:GrowingEventSendPolicyInstant];
+        NSArray *events = [self.database getEventsByCount:1 limitSize:1000000 policy:GrowingEventSendPolicyInstant];
         XCTAssertEqual(events.count, 1);
     }
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -160,7 +160,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: c24033146e037d32387883bf57f0be44f42add13
+  GrowingAnalytics: 8dd586c3ab1aa9ecbb9a628b4325aef869679b26
   GrowingAPM: 3c4de0384935b654e6798b95606f47883a99418b
   GrowingToolsKit: c1f7753484ca3e18dedb2fe083317fb19c1fecb4
   GrowingUtils: 68aee2c96849bf9b674740503da30c2da468e79d

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -71,16 +71,16 @@ PODS:
     - GrowingAPM/Core
   - GrowingAPM/UIMonitor (1.0.1):
     - GrowingAPM/Core
-  - GrowingToolsKit (2.0.1):
-    - GrowingToolsKit/Default (= 2.0.1)
-  - GrowingToolsKit/APMCore (2.0.1):
+  - GrowingToolsKit (2.0.2):
+    - GrowingToolsKit/Default (= 2.0.2)
+  - GrowingToolsKit/APMCore (2.0.2):
     - GrowingAPM/Core
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Core (2.0.1)
-  - GrowingToolsKit/CrashMonitor (2.0.1):
+  - GrowingToolsKit/Core (2.0.2)
+  - GrowingToolsKit/CrashMonitor (2.0.2):
     - GrowingAPM/CrashMonitor
     - GrowingToolsKit/APMCore
-  - GrowingToolsKit/Default (2.0.1):
+  - GrowingToolsKit/Default (2.0.2):
     - GrowingToolsKit/Core
     - GrowingToolsKit/CrashMonitor
     - GrowingToolsKit/EventsList
@@ -90,20 +90,20 @@ PODS:
     - GrowingToolsKit/SDKInfo
     - GrowingToolsKit/Settings
     - GrowingToolsKit/XPathTrack
-  - GrowingToolsKit/EventsList (2.0.1):
+  - GrowingToolsKit/EventsList (2.0.2):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/LaunchTime (2.0.1):
+  - GrowingToolsKit/LaunchTime (2.0.2):
     - GrowingAPM/UIMonitor
     - GrowingToolsKit/APMCore
-  - GrowingToolsKit/NetFlow (2.0.1):
+  - GrowingToolsKit/NetFlow (2.0.2):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Realtime (2.0.1):
+  - GrowingToolsKit/Realtime (2.0.2):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/SDKInfo (2.0.1):
+  - GrowingToolsKit/SDKInfo (2.0.2):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Settings (2.0.1):
+  - GrowingToolsKit/Settings (2.0.2):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/XPathTrack (2.0.1):
+  - GrowingToolsKit/XPathTrack (2.0.2):
     - GrowingToolsKit/Core
   - GrowingUtils/AutotrackerCore (1.2.3):
     - GrowingUtils/TrackerCore
@@ -124,12 +124,12 @@ PODS:
   - OHHTTPStubs/NSURLSession (9.1.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
-  - Protobuf (3.26.0)
+  - Protobuf (3.26.1)
   - SDCycleScrollView (1.82):
     - SDWebImage (>= 5.0.0)
-  - SDWebImage (5.19.0):
-    - SDWebImage/Core (= 5.19.0)
-  - SDWebImage/Core (5.19.0)
+  - SDWebImage (5.19.1):
+    - SDWebImage/Core (= 5.19.1)
+  - SDWebImage/Core (5.19.1)
 
 DEPENDENCIES:
   - GrowingAnalytics/ABTesting (from `../`)
@@ -162,13 +162,13 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   GrowingAnalytics: 8dd586c3ab1aa9ecbb9a628b4325aef869679b26
   GrowingAPM: 3c4de0384935b654e6798b95606f47883a99418b
-  GrowingToolsKit: c1f7753484ca3e18dedb2fe083317fb19c1fecb4
+  GrowingToolsKit: 53160d19690da0b78e04a9242abde7af86442922
   GrowingUtils: 68aee2c96849bf9b674740503da30c2da468e79d
   KIF: 7660c626b0f2d4562533590960db70a36d640558
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  Protobuf: 5685c66a07eaad9d18ce5ab618e9ac01fd04b5aa
+  Protobuf: a53f5173a603075b3522a5c50be63a67a5f3353a
   SDCycleScrollView: a0d74c3384caa72bdfc81470bdbc8c14b3e1fbcf
-  SDWebImage: 981fd7e860af070920f249fd092420006014c3eb
+  SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
 
 PODFILE CHECKSUM: 51bab161e69d216b5eff74379bef32902e83107b
 

--- a/GrowingTrackerCore/Database/GrowingEventDatabase.h
+++ b/GrowingTrackerCore/Database/GrowingEventDatabase.h
@@ -34,7 +34,7 @@
 
 - (void)setEvent:(id<GrowingEventPersistenceProtocol>)event forKey:(NSString *)key;
 
-- (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count policy:(NSUInteger)mask;
+- (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count limitSize:(NSUInteger)limitSize policy:(NSUInteger)mask;
 
 - (NSData *)buildRawEventsFromEvents:(NSArray<id<GrowingEventPersistenceProtocol>> *)events;
 

--- a/GrowingTrackerCore/Database/GrowingEventDatabase.h
+++ b/GrowingTrackerCore/Database/GrowingEventDatabase.h
@@ -34,7 +34,9 @@
 
 - (void)setEvent:(id<GrowingEventPersistenceProtocol>)event forKey:(NSString *)key;
 
-- (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count limitSize:(NSUInteger)limitSize policy:(NSUInteger)mask;
+- (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count
+                                                         limitSize:(NSUInteger)limitSize
+                                                            policy:(NSUInteger)mask;
 
 - (NSData *)buildRawEventsFromEvents:(NSArray<id<GrowingEventPersistenceProtocol>> *)events;
 

--- a/GrowingTrackerCore/Database/GrowingEventDatabase.m
+++ b/GrowingTrackerCore/Database/GrowingEventDatabase.m
@@ -183,7 +183,9 @@ NSString *const GrowingEventDatabaseErrorDomain = @"com.growing.event.database.e
     }
 }
 
-- (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count limitSize:(NSUInteger)limitSize policy:(NSUInteger)mask {
+- (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count
+                                                         limitSize:(NSUInteger)limitSize
+                                                            policy:(NSUInteger)mask {
     NSArray *events = [self.db getEventsByCount:count limitSize:limitSize policy:mask];
     if (!events) {
         [self handleDatabaseError:[self.db lastError]];

--- a/GrowingTrackerCore/Database/GrowingEventDatabase.m
+++ b/GrowingTrackerCore/Database/GrowingEventDatabase.m
@@ -183,8 +183,8 @@ NSString *const GrowingEventDatabaseErrorDomain = @"com.growing.event.database.e
     }
 }
 
-- (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count policy:(NSUInteger)mask {
-    NSArray *events = [self.db getEventsByCount:count policy:mask];
+- (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count limitSize:(NSUInteger)limitSize policy:(NSUInteger)mask {
+    NSArray *events = [self.db getEventsByCount:count limitSize:limitSize policy:mask];
     if (!events) {
         [self handleDatabaseError:[self.db lastError]];
     }

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -413,7 +413,7 @@ static GrowingEventManager *sharedInstance = nil;
     id<GrowingEventPersistenceProtocol> waitForPersist = [eventChannel.db persistenceEventWithEvent:event
                                                                                                uuid:uuidString];
     [eventChannel.db setEvent:waitForPersist forKey:uuidString];
-    
+
     if (GrowingEventSendPolicyInstant & event.sendPolicy) {
         [self sendEventsInstantWithChannel:eventChannel];
 #if defined(DEBUG) && DEBUG

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -299,14 +299,14 @@ static GrowingEventManager *sharedInstance = nil;
     }
     events = removeV3AutotrackEvents.copy;
 
-    if (events.count == 0) {
-        return;
-    }
-
     for (NSObject<GrowingEventInterceptor> *obj in self.allInterceptor) {
         if ([obj respondsToSelector:@selector(growingEventManagerEventsWillSend:channel:)]) {
             events = [obj growingEventManagerEventsWillSend:events channel:channel];
         }
+    }
+    
+    if (events.count == 0) {
+        return;
     }
 
     channel.isUploading = YES;

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -348,14 +348,14 @@ static GrowingEventManager *sharedInstance = nil;
         GIOLogError(@"-sendEventsOfChannel_unsafe: error : fail to build raw events");
         return;
     }
-    
+
     id<GrowingEventNetworkService> service =
         [[GrowingServiceManager sharedInstance] createService:@protocol(GrowingEventNetworkService)];
     if (!service) {
         GIOLogError(@"-sendEventsOfChannel_unsafe: error : no network service support");
         return;
     }
-    
+
     channel.isUploading = YES;
     NSObject<GrowingRequestProtocol> *eventRequest = [[GrowingEventRequest alloc] initWithEvents:rawEvents];
     [service sendRequest:eventRequest

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -309,8 +309,6 @@ static GrowingEventManager *sharedInstance = nil;
         return;
     }
 
-    channel.isUploading = YES;
-
 #ifdef DEBUG
     [self prettyLogForEvents:events withChannel:channel];
 #endif
@@ -341,20 +339,25 @@ static GrowingEventManager *sharedInstance = nil;
         }
 
         rawEvents = [dbClass buildRawEventsFromJsonObjects:jsonObjects];
-    }
-
-    if (!rawEvents) {
+    } else {
         // 该channel的持久化数据格式与配置相同
         rawEvents = [channel.db buildRawEventsFromEvents:events];
     }
 
-    NSObject<GrowingRequestProtocol> *eventRequest = [[GrowingEventRequest alloc] initWithEvents:rawEvents];
+    if (!rawEvents) {
+        GIOLogError(@"-sendEventsOfChannel_unsafe: error : fail to build raw events");
+        return;
+    }
+    
     id<GrowingEventNetworkService> service =
         [[GrowingServiceManager sharedInstance] createService:@protocol(GrowingEventNetworkService)];
     if (!service) {
         GIOLogError(@"-sendEventsOfChannel_unsafe: error : no network service support");
         return;
     }
+    
+    channel.isUploading = YES;
+    NSObject<GrowingRequestProtocol> *eventRequest = [[GrowingEventRequest alloc] initWithEvents:rawEvents];
     [service sendRequest:eventRequest
               completion:^(NSHTTPURLResponse *_Nonnull httpResponse, NSData *_Nonnull data, NSError *_Nonnull error) {
                   if (error) {

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -431,7 +431,7 @@ static GrowingEventManager *sharedInstance = nil;
 
 - (NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsToBeUploadUnsafe:(GrowingEventChannel *)channel
                                                                      policy:(NSUInteger)mask {
-    return [channel.db getEventsByCount:kGrowingMaxBatchSize policy:mask];
+    return [channel.db getEventsByCount:kGrowingMaxBatchSize limitSize:2 * kGrowingUnit_MB policy:mask];
 }
 
 #pragma mark Event Log

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -413,10 +413,16 @@ static GrowingEventManager *sharedInstance = nil;
     id<GrowingEventPersistenceProtocol> waitForPersist = [eventChannel.db persistenceEventWithEvent:event
                                                                                                uuid:uuidString];
     [eventChannel.db setEvent:waitForPersist forKey:uuidString];
-
-    BOOL debugEnabled = GrowingConfigurationManager.sharedInstance.trackConfiguration.debugEnabled;
-    if (GrowingEventSendPolicyInstant & event.sendPolicy || debugEnabled) {  // send event instantly
+    
+    if (GrowingEventSendPolicyInstant & event.sendPolicy) {
         [self sendEventsInstantWithChannel:eventChannel];
+#if defined(DEBUG) && DEBUG
+    } else {
+        BOOL debugEnabled = GrowingConfigurationManager.sharedInstance.trackConfiguration.debugEnabled;
+        if (debugEnabled) {
+            [self sendEventsInstantWithChannel:eventChannel];
+        }
+#endif
     }
 }
 

--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -304,7 +304,7 @@ static GrowingEventManager *sharedInstance = nil;
             events = [obj growingEventManagerEventsWillSend:events channel:channel];
         }
     }
-    
+
     if (events.count == 0) {
         return;
     }

--- a/GrowingTrackerCore/GrowingTrackConfiguration.m
+++ b/GrowingTrackerCore/GrowingTrackConfiguration.m
@@ -61,7 +61,7 @@ NSString *const kGrowingDefaultABTestingServerHost = @"https://ab.growingio.com"
         _idMappingEnabled = NO;
         _urlScheme = nil;
         _encryptEnabled = NO;
-        _compressEnabled = YES;
+        _compressEnabled = NO;
         _networkConfig = nil;
         _useProtobuf = YES;
 

--- a/GrowingTrackerCore/GrowingTrackConfiguration.m
+++ b/GrowingTrackerCore/GrowingTrackConfiguration.m
@@ -61,6 +61,7 @@ NSString *const kGrowingDefaultABTestingServerHost = @"https://ab.growingio.com"
         _idMappingEnabled = NO;
         _urlScheme = nil;
         _encryptEnabled = NO;
+        _compressEnabled = YES;
         _networkConfig = nil;
         _useProtobuf = YES;
 
@@ -105,6 +106,7 @@ NSString *const kGrowingDefaultABTestingServerHost = @"https://ab.growingio.com"
     configuration->_idMappingEnabled = _idMappingEnabled;
     configuration->_urlScheme = _urlScheme;
     configuration->_encryptEnabled = _encryptEnabled;
+    configuration->_compressEnabled = _compressEnabled;
     configuration->_networkConfig = [_networkConfig copy];
     configuration->_useProtobuf = _useProtobuf;
 

--- a/GrowingTrackerCore/Public/GrowingEventDatabaseService.h
+++ b/GrowingTrackerCore/Public/GrowingEventDatabaseService.h
@@ -67,9 +67,10 @@ extern NSString *const GrowingEventDatabaseErrorDomain;
 
 /// 获取事件
 /// @param count 数量
+/// @param limitSize 大小限制
 /// @param mask 允许的发送协议（数组）
 /// @return 事件对象数组，可为空；若返回值为nil，表示读取错误
-- (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count policy:(NSUInteger)mask;
+- (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count limitSize:(NSUInteger)limitSize policy:(NSUInteger)mask;
 
 /// 写入事件数据
 /// @param event 事件数据

--- a/GrowingTrackerCore/Public/GrowingEventDatabaseService.h
+++ b/GrowingTrackerCore/Public/GrowingEventDatabaseService.h
@@ -70,7 +70,9 @@ extern NSString *const GrowingEventDatabaseErrorDomain;
 /// @param limitSize 大小限制
 /// @param mask 允许的发送协议（数组）
 /// @return 事件对象数组，可为空；若返回值为nil，表示读取错误
-- (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count limitSize:(NSUInteger)limitSize policy:(NSUInteger)mask;
+- (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count
+                                                                  limitSize:(NSUInteger)limitSize
+                                                                     policy:(NSUInteger)mask;
 
 /// 写入事件数据
 /// @param event 事件数据

--- a/GrowingTrackerCore/Public/GrowingTrackConfiguration.h
+++ b/GrowingTrackerCore/Public/GrowingTrackConfiguration.h
@@ -40,6 +40,7 @@ FOUNDATION_EXPORT NSString *const kGrowingDefaultDataCollectionServerHost;
 @property (nonatomic, assign) BOOL idMappingEnabled;
 @property (nonatomic, copy) NSString *urlScheme;
 @property (nonatomic, assign) BOOL encryptEnabled;
+@property (nonatomic, assign) BOOL compressEnabled;
 @property (nonatomic, copy) GrowingNetworkConfig *networkConfig;
 @property (nonatomic, assign) BOOL useProtobuf;
 

--- a/Modules/DefaultServices/GrowingEventRequestCompressionAdapter.m
+++ b/Modules/DefaultServices/GrowingEventRequestCompressionAdapter.m
@@ -36,20 +36,17 @@
 }
 
 - (NSMutableURLRequest *)adaptedURLRequest:(NSMutableURLRequest *)request {
+    if (![self.request respondsToSelector:@selector(events)] || 
+        self.request.events.length == 0) {
+        return request;
+    }
     NSMutableURLRequest *needAdaptReq = request;
-    BOOL encryptEnabled = GrowingConfigurationManager.sharedInstance.trackConfiguration.encryptEnabled;
-    if (encryptEnabled) {
-        [needAdaptReq setValue:@"3" forHTTPHeaderField:@"X-Compress-Codec"];
-    }
-
-    if (![self.request respondsToSelector:@selector(events)] || self.request.events.length == 0) {
-        return nil;
-    }
     NSData *JSONData = self.request.events.copy;
-    @autoreleasepool {
-        // jsonString malloc to much
-        BOOL encryptEnabled = GrowingConfigurationManager.sharedInstance.trackConfiguration.encryptEnabled;
-        if (encryptEnabled) {
+    BOOL compressEnabled = GrowingConfigurationManager.sharedInstance.trackConfiguration.compressEnabled;
+    if (compressEnabled) {
+        [needAdaptReq setValue:@"3" forHTTPHeaderField:@"X-Compress-Codec"];
+
+        @autoreleasepool {
             JSONData = [JSONData growingHelper_LZ4String];
         }
     }

--- a/Modules/DefaultServices/GrowingEventRequestCompressionAdapter.m
+++ b/Modules/DefaultServices/GrowingEventRequestCompressionAdapter.m
@@ -36,8 +36,7 @@
 }
 
 - (NSMutableURLRequest *)adaptedURLRequest:(NSMutableURLRequest *)request {
-    if (![self.request respondsToSelector:@selector(events)] || 
-        self.request.events.length == 0) {
+    if (![self.request respondsToSelector:@selector(events)] || self.request.events.length == 0) {
         return request;
     }
     NSMutableURLRequest *needAdaptReq = request;

--- a/Modules/DefaultServices/GrowingEventRequestEncryptionAdapter.m
+++ b/Modules/DefaultServices/GrowingEventRequestEncryptionAdapter.m
@@ -36,27 +36,22 @@
 }
 
 - (NSMutableURLRequest *)adaptedURLRequest:(NSMutableURLRequest *)request {
-    if (request.HTTPBody.length == 0) {
+    if (![self.request respondsToSelector:@selector(stm)] || 
+        request.HTTPBody.length == 0) {
         return request;
     }
-
     NSMutableURLRequest *needAdaptReq = request;
     BOOL encryptEnabled = GrowingConfigurationManager.sharedInstance.trackConfiguration.encryptEnabled;
     if (encryptEnabled) {
         [needAdaptReq setValue:@"1" forHTTPHeaderField:@"X-Crypt-Codec"];
-    }
-
-    NSData *JSONData = needAdaptReq.HTTPBody.copy;
-    @autoreleasepool {
-        // jsonString malloc to much
-        BOOL encryptEnabled = GrowingConfigurationManager.sharedInstance.trackConfiguration.encryptEnabled;
-        if (encryptEnabled) {
-            if ([self.request respondsToSelector:@selector(stm)]) {
-                JSONData = [JSONData growingHelper_xorEncryptWithHint:(self.request.stm & 0xFF)];
-            }
+        
+        NSData *JSONData = needAdaptReq.HTTPBody.copy;
+        @autoreleasepool {
+            // jsonString malloc to much
+            JSONData = [JSONData growingHelper_xorEncryptWithHint:(self.request.stm & 0xFF)];
         }
+        needAdaptReq.HTTPBody = JSONData;
     }
-    needAdaptReq.HTTPBody = JSONData;
     return needAdaptReq;
 }
 

--- a/Modules/DefaultServices/GrowingEventRequestEncryptionAdapter.m
+++ b/Modules/DefaultServices/GrowingEventRequestEncryptionAdapter.m
@@ -36,15 +36,14 @@
 }
 
 - (NSMutableURLRequest *)adaptedURLRequest:(NSMutableURLRequest *)request {
-    if (![self.request respondsToSelector:@selector(stm)] || 
-        request.HTTPBody.length == 0) {
+    if (![self.request respondsToSelector:@selector(stm)] || request.HTTPBody.length == 0) {
         return request;
     }
     NSMutableURLRequest *needAdaptReq = request;
     BOOL encryptEnabled = GrowingConfigurationManager.sharedInstance.trackConfiguration.encryptEnabled;
     if (encryptEnabled) {
         [needAdaptReq setValue:@"1" forHTTPHeaderField:@"X-Crypt-Codec"];
-        
+
         NSData *JSONData = needAdaptReq.HTTPBody.copy;
         @autoreleasepool {
             // jsonString malloc to much

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -106,7 +106,9 @@
     return count;
 }
 
-- (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count limitSize:(NSUInteger)limitSize policy:(NSUInteger)mask {
+- (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count
+                                                                  limitSize:(NSUInteger)limitSize
+                                                                     policy:(NSUInteger)mask {
     if (self.countOfEvents == 0) {
         return [[NSArray alloc] init];
     }

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -109,8 +109,11 @@
 - (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count
                                                                   limitSize:(NSUInteger)limitSize
                                                                      policy:(NSUInteger)mask {
-    if (self.countOfEvents == 0) {
+    NSInteger countOfEvents = [self countOfEvents];
+    if (countOfEvents == 0) {
         return [[NSArray alloc] init];
+    } else if (countOfEvents == -1) {
+        return nil;
     }
 
     NSMutableArray<id<GrowingEventPersistenceProtocol>> *events = [[NSMutableArray alloc] init];

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -125,7 +125,11 @@
                                                                                                      data:value
                                                                                                    policy:policy
                                                                                                sdkVersion:sdkVersion];
-            eventsLength += [value length];
+            if ([value isKindOfClass:[NSString class]]) {
+                eventsLength += [(NSString *)value dataUsingEncoding:NSUTF8StringEncoding].length;
+            } else if ([value isKindOfClass:[NSData class]]) {
+                eventsLength += [(NSData *)value length];
+            }
             if (eventsLength >= limitSize) {
                 **stop = YES;
             } else {

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -132,7 +132,7 @@
                 **stop = YES;
             } else {
                 [events addObject:event];
-                
+
                 if (events.count >= count) {
                     **stop = YES;
                 }

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -86,11 +86,13 @@
     [self performDatabaseBlock:^(GrowingFMDatabase *db, NSError *error) {
         if (error) {
             self.databaseError = error;
+            count = -1;
             return;
         }
         GrowingFMResultSet *set = [db executeQuery:@"SELECT COUNT(*) FROM namedcachetable"];
         if (!set) {
             self.databaseError = [self readErrorInDatabase:db];
+            count = -1;
             return;
         }
 
@@ -107,7 +109,7 @@
 - (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count
                                                                   limitSize:(NSUInteger)limitSize
                                                                      policy:(NSUInteger)mask {
-    if (self.countOfEvents <= 0) {
+    if (self.countOfEvents == 0) {
         return [[NSArray alloc] init];
     }
 

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -365,7 +365,7 @@ static BOOL isExecuteVacuum(NSString *name) {
     if (name.length == 0) {
         return NO;
     }
-    NSString *vacuumDate = [NSString stringWithFormat:@"GIO_VACUUM_DATE_E7B96C4E-6EE2-49CD-87F0-B2E62D4EE96A-%@", name];
+    NSString *vacuumDate = [NSString stringWithFormat:@"GROWINGIO_VACUUM_DATE_%@", name];
     NSUserDefaults *userDefault = [NSUserDefaults standardUserDefaults];
     NSDate *beforeDate = [userDefault objectForKey:vacuumDate];
     NSDate *nowDate = [NSDate date];
@@ -375,7 +375,7 @@ static BOOL isExecuteVacuum(NSString *name) {
                                                                   fromDate:beforeDate
                                                                     toDate:nowDate
                                                                    options:0];
-        BOOL flag = delta.day > 7 || delta.day < 0;
+        BOOL flag = delta.day > 3 || delta.day < 0;
         if (flag) {
             [userDefault setObject:nowDate forKey:vacuumDate];
             [userDefault synchronize];

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -106,12 +106,13 @@
     return count;
 }
 
-- (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count policy:(NSUInteger)mask {
+- (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count limitSize:(NSUInteger)limitSize policy:(NSUInteger)mask {
     if (self.countOfEvents == 0) {
         return [[NSArray alloc] init];
     }
 
     NSMutableArray<id<GrowingEventPersistenceProtocol>> *events = [[NSMutableArray alloc] init];
+    __block NSUInteger eventsLength = 0;
     [self enumerateKeysAndValuesUsingBlock:^(NSString *key,
                                              id value,
                                              NSString *type,
@@ -125,7 +126,10 @@
                                                                                                    policy:policy
                                                                                                sdkVersion:sdkVersion];
             [events addObject:event];
-            if (events.count >= count) {
+            eventsLength += [value length];
+            if (eventsLength >= limitSize) {
+                **stop = YES;
+            } else if (events.count >= count) {
                 **stop = YES;
             }
         }

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -86,13 +86,11 @@
     [self performDatabaseBlock:^(GrowingFMDatabase *db, NSError *error) {
         if (error) {
             self.databaseError = error;
-            count = -1;
             return;
         }
         GrowingFMResultSet *set = [db executeQuery:@"SELECT COUNT(*) FROM namedcachetable"];
         if (!set) {
             self.databaseError = [self readErrorInDatabase:db];
-            count = -1;
             return;
         }
 
@@ -109,7 +107,7 @@
 - (nullable NSArray<id<GrowingEventPersistenceProtocol>> *)getEventsByCount:(NSUInteger)count
                                                                   limitSize:(NSUInteger)limitSize
                                                                      policy:(NSUInteger)mask {
-    if (self.countOfEvents == 0) {
+    if (self.countOfEvents <= 0) {
         return [[NSArray alloc] init];
     }
 

--- a/Services/Database/GrowingEventFMDatabase.m
+++ b/Services/Database/GrowingEventFMDatabase.m
@@ -127,12 +127,15 @@
                                                                                                      data:value
                                                                                                    policy:policy
                                                                                                sdkVersion:sdkVersion];
-            [events addObject:event];
             eventsLength += [value length];
             if (eventsLength >= limitSize) {
                 **stop = YES;
-            } else if (events.count >= count) {
-                **stop = YES;
+            } else {
+                [events addObject:event];
+                
+                if (events.count >= count) {
+                    **stop = YES;
+                }
             }
         }
     }];


### PR DESCRIPTION
* 添加从数据库获取事件的 data 总长度限制：2MB
* 修复在打开 ASAEnabled 时，因 ACTIVATE 事件延迟发送，从而 events.count 可能为 0，对应的 URLRequest 生成为 nil，导致崩溃产生
* 修复其他可能导致崩溃的场景
* vacuum 操作改为 3 天/次
* 将 encryptEnabled 配置分为 compressEnabled (默认 false) 和 encryptEnabled (默认 false)
* 在 release 环境下，将不再由于 debugEnabled 为 true 而频繁发送事件