### PR TITLE
fix(perf): func growingHelper_beautifulJsonString waste a lot of cpu time

### DIFF
--- a/GrowingTrackerCore/Event/GrowingEventManager.m
+++ b/GrowingTrackerCore/Event/GrowingEventManager.m
@@ -377,9 +377,11 @@ static GrowingEventManager *sharedInstance = nil;
 #pragma mark Event Persist
 
 - (void)writeToDatabaseWithEvent:(GrowingBaseEvent *)event {
+#if defined(DEBUG) && DEBUG
     GIOLogDebug(@"save: event, type is %@\n%@",
                 event.eventType,
                 [event.toDictionary growingHelper_beautifulJsonString]);
+#endif
     NSString *eventType = event.eventType;
 
     if (!event) {


### PR DESCRIPTION
使用 instrument 测试发现，打印日志所需调用的 `growingHelper_beautifulJsonString` 函数在 Release 环境下也会调用，导致占用 SDK 线程 15%+ (取决于当前同一时间触发的埋点数，埋点数越多，占用越高) 的 cpu 时间
![image](https://github.com/growingio/growingio-sdk-ios-autotracker/assets/16042670/72d05944-dcd5-46c7-8c4f-12dd0ff50517)

此 PR 使得在 Release 环境下，不再意外调用 `growingHelper_beautifulJsonString` 函数