### PR TITLE
ci: use macos-12 instead of macos-14-arm64(current latest runner image)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       DERIVED_DATA: $HOME/.DerivedData
 


### PR DESCRIPTION
在 macos-14-arm64 上，iOS simulator 无法正常启动，导致单测长时间卡住不动，目前先降级到 macos-12，等待官方修复

见：https://github.com/actions/runner-images/issues/9591