### PR TITLE
fix: change imp attributes type to [String: Any]

### DIFF
--- a/Example/Example-tvOS/Base.lproj/Main.storyboard
+++ b/Example/Example-tvOS/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="22505" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="32700.99.1234" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="appleTV" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,15 +21,39 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dPC-6W-Dib">
-                                <rect key="frame" x="877" y="503" width="166" height="75"/>
+                                <rect key="frame" x="899" y="307" width="146" height="75"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Button">
+                                <buttonConfiguration key="configuration" style="plain" title="track">
                                     <color key="baseForegroundColor" name="AccentColor"/>
                                 </buttonConfiguration>
                                 <connections>
                                     <action selector="buttonAction:" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="Dkr-CW-Ps5"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a9h-O3-V3g">
+                                <rect key="frame" x="867" y="433" width="210" height="75"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="showAlert">
+                                    <color key="baseForegroundColor" name="AccentColor"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="showAlert:" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="8uC-Uo-kJO"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9el-uq-kTO">
+                                <rect key="frame" x="819" y="577" width="307" height="75"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="showActionSheet">
+                                    <color key="baseForegroundColor" name="AccentColor"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="showActionSheet:" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="1ut-zQ-mUz"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -38,7 +63,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-46" y="-74"/>
+            <point key="canvasLocation" x="183" y="-94"/>
         </scene>
     </scenes>
     <resources>

--- a/Example/Example-tvOS/ViewController.swift
+++ b/Example/Example-tvOS/ViewController.swift
@@ -33,5 +33,31 @@ class ViewController: UIViewController {
         GrowingAutotracker.sharedInstance().trackCustomEvent("tvOS_custom_event", withAttributes: ["key2": "value"])
     }
     
+    @IBAction func showAlert(_ sender: UIButton) {
+        let title = "title"
+        let message = "message"
+        let controller = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in
+            
+        }))
+        controller.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
+            
+        }))
+        self.present(controller, animated: true)
+    }
+    
+    @IBAction func showActionSheet(_ sender: UIButton) {
+        let title = "title"
+        let message = "message"
+        let controller = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in
+            
+        }))
+        controller.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
+            
+        }))
+        self.present(controller, animated: true)
+    }
+    
 }
 

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 		34FBF18D2B6A2C1C008C7587 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FBF18C2B6A2C1C008C7587 /* ContentView.swift */; };
 		34FBF18F2B6A2C1C008C7587 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 34FBF18E2B6A2C1C008C7587 /* Assets.xcassets */; };
 		34FBF1922B6A2C1C008C7587 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 34FBF1912B6A2C1C008C7587 /* Preview Assets.xcassets */; };
-		34FBF1952B6A2C1C008C7587 /* Example-watchOS Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 34FBF1882B6A2C1C008C7587 /* Example-watchOS Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		34FBF1952B6A2C1C008C7587 /* Example-watchOS Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 34FBF1882B6A2C1C008C7587 /* Example-watchOS Watch App.app */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		34FBF19B2B6A3A15008C7587 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FBF19A2B6A3A15008C7587 /* AppDelegate.swift */; };
 		34FCF7E12A937ECA009611B3 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FCF7E02A937ECA009611B3 /* SwiftUIView.swift */; };
 		34FCF7E42A937F4F009611B3 /* GIOSwiftUIContentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FCF7E32A937F4F009611B3 /* GIOSwiftUIContentViewController.m */; };
@@ -3124,6 +3124,7 @@
 		};
 		34FBF1942B6A2C1C008C7587 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilter = ios;
 			target = 34FBF1872B6A2C1C008C7587 /* Example-watchOS Watch App */;
 			targetProxy = 34FBF1932B6A2C1C008C7587 /* PBXContainerItemProxy */;
 		};

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		9FA660A104463603E4710774 /* Pods_Example_SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4740916E28995032051C9BE /* Pods_Example_SwiftUI.framework */; };
 		A61E1E81175885070AAD10A9 /* Pods_ExampleiOS13.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7CCC2E00F858DC5B58D4FA6 /* Pods_ExampleiOS13.framework */; };
 		A9D21D06460258FAC4736A26 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90476D1583D0EE778FCBED5E /* Pods_Example.framework */; };
+		B6E5EE37C83774A528C6AD8F /* Pods_Example_visionOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75836C865E564A00DA49A94D /* Pods_Example_visionOS.framework */; };
 		DC414ADEC8E1A738BA63089E /* Pods_AdvertisingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5655CC09B9A2CE16091DB52F /* Pods_AdvertisingTests.framework */; };
 		FA78740F8B45E99B90F73157 /* Pods_Example_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24881A4A149E400F80B69E2A /* Pods_Example_tvOS.framework */; };
 /* End PBXBuildFile section */
@@ -544,6 +545,7 @@
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		68B97EA7A6285797FDDCE335 /* Pods-AdvertisingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdvertisingTests.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-AdvertisingTests/Pods-AdvertisingTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6F9B4F11B90235A2D461CA2C /* Pods-GrowingAnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GrowingAnalyticsTests.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-GrowingAnalyticsTests/Pods-GrowingAnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		75836C865E564A00DA49A94D /* Pods_Example_visionOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_visionOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B524BD63EF3439946134E74 /* Pods_Example_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		835401C6A4C9E2141838BE84 /* Pods-Example-watchOS Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-watchOS Watch App.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-Example-watchOS Watch App/Pods-Example-watchOS Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		8899A83F721CB9CFF4C9D7F9 /* Pods-ShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShareExtension.release.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-ShareExtension/Pods-ShareExtension.release.xcconfig"; sourceTree = "<group>"; };
@@ -554,6 +556,7 @@
 		B2DC29AD1846CC827998F01D /* Pods-ProtobufTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufTests.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-ProtobufTests/Pods-ProtobufTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BBC64B438435E91D8D408C70 /* Pods-Example-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-macOS.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-Example-macOS/Pods-Example-macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		BDF26A896226E51F6DD6DA0E /* Pods_ShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C1A178DA1745A23701017EFC /* Pods-Example-visionOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-visionOS.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-Example-visionOS/Pods-Example-visionOS.debug.xcconfig"; sourceTree = "<group>"; };
 		C2E2C01C3AC89773BC3F4BE1 /* Pods_ProtobufTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProtobufTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3770B519AE17A95967F4D21 /* Pods-Example-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-tvOS.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-Example-tvOS/Pods-Example-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		C7BA7AC57B5EDD2EE021AFF8 /* Pods-Example-SwiftUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-SwiftUI.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-Example-SwiftUI/Pods-Example-SwiftUI.debug.xcconfig"; sourceTree = "<group>"; };
@@ -569,6 +572,7 @@
 		E3A2065A7EA394ECBE6D2F68 /* Pods-Example-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-tvOS.release.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-Example-tvOS/Pods-Example-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		F625366B1611DA7E27D0E32C /* Pods-ExampleiOS13.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleiOS13.debug.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-ExampleiOS13/Pods-ExampleiOS13.debug.xcconfig"; sourceTree = "<group>"; };
 		FAB05E3514907518EF7B9514 /* Pods-HostApplicationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApplicationTests.release.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-HostApplicationTests/Pods-HostApplicationTests.release.xcconfig"; sourceTree = "<group>"; };
+		FC90C36FE728085C7DEC3EBF /* Pods-Example-visionOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-visionOS.release.xcconfig"; path = "../Example/Pods/Target Support Files/Pods-Example-visionOS/Pods-Example-visionOS.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -697,6 +701,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA78740F8B45E99B90F73157 /* Pods_Example_tvOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ABFD529355B73398E456F762 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B6E5EE37C83774A528C6AD8F /* Pods_Example_visionOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -909,6 +921,8 @@
 				E3A2065A7EA394ECBE6D2F68 /* Pods-Example-tvOS.release.xcconfig */,
 				C7BA7AC57B5EDD2EE021AFF8 /* Pods-Example-SwiftUI.debug.xcconfig */,
 				C99DCCBFAEA542234FF81780 /* Pods-Example-SwiftUI.release.xcconfig */,
+				C1A178DA1745A23701017EFC /* Pods-Example-visionOS.debug.xcconfig */,
+				FC90C36FE728085C7DEC3EBF /* Pods-Example-visionOS.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -1657,6 +1671,7 @@
 				358137F6293DF184E03C3572 /* Pods_Example_watchOS_Watch_App.framework */,
 				24881A4A149E400F80B69E2A /* Pods_Example_tvOS.framework */,
 				D4740916E28995032051C9BE /* Pods_Example_SwiftUI.framework */,
+				75836C865E564A00DA49A94D /* Pods_Example_visionOS.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1857,8 +1872,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34DAD9AA2B6F919F00760A9C /* Build configuration list for PBXNativeTarget "Example-visionOS" */;
 			buildPhases = (
+				46D8FB44F863A4AD7BCA7B4E /* [CP] Check Pods Manifest.lock */,
 				34DAD9942B6F919E00760A9C /* Sources */,
 				34DAD9962B6F919E00760A9C /* Resources */,
+				ABFD529355B73398E456F762 /* Frameworks */,
+				23AF2C2CA1B403A3D659036D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2380,6 +2398,28 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		23AF2C2CA1B403A3D659036D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Example-visionOS/Pods-Example-visionOS-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GrowingAnalytics-488a3cda/GrowingAnalytics.framework",
+				"${BUILT_PRODUCTS_DIR}/GrowingUtils-TrackerCore-visionOS/GrowingUtils.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf-visionOS/Protobuf.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingAnalytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GrowingUtils.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example-visionOS/Pods-Example-visionOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		343BCF0CA69BCDF66483968C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2440,6 +2480,28 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-ProtobufTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		46D8FB44F863A4AD7BCA7B4E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Example-visionOS-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -4185,6 +4247,7 @@
 		};
 		34DAD9A82B6F919F00760A9C /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C1A178DA1745A23701017EFC /* Pods-Example-visionOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -4238,6 +4301,7 @@
 		};
 		34DAD9A92B6F919F00760A9C /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FC90C36FE728085C7DEC3EBF /* Pods-Example-visionOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -97,10 +97,10 @@ target 'Example-tvOS' do
   pod 'GrowingAnalytics/Autotracker', :path => '../'
 end
 
-# target 'Example-visionOS' do
-#   platform :visionos, '1.0'
-#   pod 'GrowingAnalytics/Tracker', :path => '../'
-# end
+target 'Example-visionOS' do
+  platform :visionos, '1.0'
+  pod 'GrowingAnalytics/Tracker', :path => '../'
+end
 
 target 'Example-SwiftUI' do
   pod 'GrowingAnalytics/Autotracker', :path => '../'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,66 +1,66 @@
 PODS:
-  - GrowingAnalytics/ABTesting (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/Ads (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/APM (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
+  - GrowingAnalytics/ABTesting (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/Ads (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/APM (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
     - GrowingAPM/Core (~> 1.0.1)
-  - GrowingAnalytics/Autotracker (4.2.0):
-    - GrowingAnalytics/AutotrackerCore (= 4.2.0)
-    - GrowingAnalytics/DefaultServices (= 4.2.0)
-    - GrowingAnalytics/Hybrid (= 4.2.0)
-    - GrowingAnalytics/MobileDebugger (= 4.2.0)
-    - GrowingAnalytics/WebCircle (= 4.2.0)
-  - GrowingAnalytics/AutotrackerCore (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
+  - GrowingAnalytics/Autotracker (4.3.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.3.0)
+    - GrowingAnalytics/DefaultServices (= 4.3.0)
+    - GrowingAnalytics/Hybrid (= 4.3.0)
+    - GrowingAnalytics/MobileDebugger (= 4.3.0)
+    - GrowingAnalytics/WebCircle (= 4.3.0)
+  - GrowingAnalytics/AutotrackerCore (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
     - GrowingUtils/AutotrackerCore (~> 1.2.3)
-  - GrowingAnalytics/Compression (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/Database (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/DefaultServices (4.2.0):
-    - GrowingAnalytics/Compression (= 4.2.0)
-    - GrowingAnalytics/Encryption (= 4.2.0)
-    - GrowingAnalytics/JSON (= 4.2.0)
-    - GrowingAnalytics/Network (= 4.2.0)
-    - GrowingAnalytics/Protobuf (= 4.2.0)
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/Encryption (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/Hybrid (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/ImpressionTrack (4.2.0):
-    - GrowingAnalytics/AutotrackerCore (= 4.2.0)
-  - GrowingAnalytics/JSON (4.2.0):
-    - GrowingAnalytics/Database (= 4.2.0)
-  - GrowingAnalytics/MobileDebugger (4.2.0):
-    - GrowingAnalytics/Screenshot (= 4.2.0)
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-    - GrowingAnalytics/WebSocket (= 4.2.0)
-  - GrowingAnalytics/Network (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/Protobuf (4.2.0):
-    - GrowingAnalytics/Database (= 4.2.0)
-    - GrowingAnalytics/Protobuf/Proto (= 4.2.0)
-  - GrowingAnalytics/Protobuf/Proto (4.2.0):
-    - GrowingAnalytics/Database (= 4.2.0)
+  - GrowingAnalytics/Compression (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/Database (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/DefaultServices (4.3.0):
+    - GrowingAnalytics/Compression (= 4.3.0)
+    - GrowingAnalytics/Encryption (= 4.3.0)
+    - GrowingAnalytics/JSON (= 4.3.0)
+    - GrowingAnalytics/Network (= 4.3.0)
+    - GrowingAnalytics/Protobuf (= 4.3.0)
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/Encryption (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/Hybrid (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/ImpressionTrack (4.3.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.3.0)
+  - GrowingAnalytics/JSON (4.3.0):
+    - GrowingAnalytics/Database (= 4.3.0)
+  - GrowingAnalytics/MobileDebugger (4.3.0):
+    - GrowingAnalytics/Screenshot (= 4.3.0)
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+    - GrowingAnalytics/WebSocket (= 4.3.0)
+  - GrowingAnalytics/Network (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/Protobuf (4.3.0):
+    - GrowingAnalytics/Database (= 4.3.0)
+    - GrowingAnalytics/Protobuf/Proto (= 4.3.0)
+  - GrowingAnalytics/Protobuf/Proto (4.3.0):
+    - GrowingAnalytics/Database (= 4.3.0)
     - Protobuf (>= 3.22.0)
-  - GrowingAnalytics/Screenshot (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/Tracker (4.2.0):
-    - GrowingAnalytics/DefaultServices (= 4.2.0)
-    - GrowingAnalytics/MobileDebugger (= 4.2.0)
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
-  - GrowingAnalytics/TrackerCore (4.2.0):
+  - GrowingAnalytics/Screenshot (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/Tracker (4.3.0):
+    - GrowingAnalytics/DefaultServices (= 4.3.0)
+    - GrowingAnalytics/MobileDebugger (= 4.3.0)
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
+  - GrowingAnalytics/TrackerCore (4.3.0):
     - GrowingUtils/TrackerCore (~> 1.2.3)
-  - GrowingAnalytics/WebCircle (4.2.0):
-    - GrowingAnalytics/AutotrackerCore (= 4.2.0)
-    - GrowingAnalytics/Hybrid (= 4.2.0)
-    - GrowingAnalytics/Screenshot (= 4.2.0)
-    - GrowingAnalytics/WebSocket (= 4.2.0)
-  - GrowingAnalytics/WebSocket (4.2.0):
-    - GrowingAnalytics/TrackerCore (= 4.2.0)
+  - GrowingAnalytics/WebCircle (4.3.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.3.0)
+    - GrowingAnalytics/Hybrid (= 4.3.0)
+    - GrowingAnalytics/Screenshot (= 4.3.0)
+    - GrowingAnalytics/WebSocket (= 4.3.0)
+  - GrowingAnalytics/WebSocket (4.3.0):
+    - GrowingAnalytics/TrackerCore (= 4.3.0)
   - GrowingAPM (1.0.1):
     - GrowingAPM/Core (= 1.0.1)
     - GrowingAPM/CrashMonitor (= 1.0.1)
@@ -160,7 +160,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: 8dd586c3ab1aa9ecbb9a628b4325aef869679b26
+  GrowingAnalytics: e72c414e3511039ea8010296678232eed7411833
   GrowingAPM: 3c4de0384935b654e6798b95606f47883a99418b
   GrowingToolsKit: 53160d19690da0b78e04a9242abde7af86442922
   GrowingUtils: 68aee2c96849bf9b674740503da30c2da468e79d

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
     - GrowingAnalytics/Protobuf/Proto (= 4.3.0)
   - GrowingAnalytics/Protobuf/Proto (4.3.0):
     - GrowingAnalytics/Database (= 4.3.0)
-    - Protobuf (>= 3.22.0)
+    - Protobuf (~> 3.27)
   - GrowingAnalytics/Screenshot (4.3.0):
     - GrowingAnalytics/TrackerCore (= 4.3.0)
   - GrowingAnalytics/Tracker (4.3.0):
@@ -108,9 +108,9 @@ PODS:
   - GrowingUtils/AutotrackerCore (1.2.3):
     - GrowingUtils/TrackerCore
   - GrowingUtils/TrackerCore (1.2.3)
-  - KIF (3.8.9):
-    - KIF/Core (= 3.8.9)
-  - KIF/Core (3.8.9)
+  - KIF (3.9.0):
+    - KIF/Core (= 3.9.0)
+  - KIF/Core (3.9.0)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -124,12 +124,12 @@ PODS:
   - OHHTTPStubs/NSURLSession (9.1.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
-  - Protobuf (3.26.1)
+  - Protobuf (3.27.0)
   - SDCycleScrollView (1.82):
     - SDWebImage (>= 5.0.0)
-  - SDWebImage (5.19.1):
-    - SDWebImage/Core (= 5.19.1)
-  - SDWebImage/Core (5.19.1)
+  - SDWebImage (5.19.2):
+    - SDWebImage/Core (= 5.19.2)
+  - SDWebImage/Core (5.19.2)
 
 DEPENDENCIES:
   - GrowingAnalytics/ABTesting (from `../`)
@@ -160,16 +160,16 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: e72c414e3511039ea8010296678232eed7411833
+  GrowingAnalytics: db127985c0799074bbd131991296195fc65efdd0
   GrowingAPM: 3c4de0384935b654e6798b95606f47883a99418b
   GrowingToolsKit: 53160d19690da0b78e04a9242abde7af86442922
   GrowingUtils: 68aee2c96849bf9b674740503da30c2da468e79d
-  KIF: 7660c626b0f2d4562533590960db70a36d640558
+  KIF: 2bd28f6c15e5b448d578668586acc8c3fe603f06
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  Protobuf: a53f5173a603075b3522a5c50be63a67a5f3353a
+  Protobuf: 2c02b2e18bb9040d3bf3fd2cecaefb2a8b55265b
   SDCycleScrollView: a0d74c3384caa72bdfc81470bdbc8c14b3e1fbcf
-  SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
+  SDWebImage: dfe95b2466a9823cf9f0c6d01217c06550d7b29a
 
-PODFILE CHECKSUM: 51bab161e69d216b5eff74379bef32902e83107b
+PODFILE CHECKSUM: 8ef4d85701caba0f5df403432dc182d34412ab4a
 
 COCOAPODS: 1.15.2

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -13,7 +13,7 @@ GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和�
   s.osx.deployment_target = '10.12'
   s.watchos.deployment_target = '7.0'
   s.tvos.deployment_target = '12.0'
-  # s.visionos.deployment_target = '1.0'
+  s.visionos.deployment_target = '1.0'
   s.ios.framework = 'WebKit'
   s.requires_arc = true
   s.default_subspec = "Autotracker"
@@ -86,7 +86,7 @@ GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和�
       proto.source_files = 'Services/Protobuf/Proto/**/*{.h,.m,.c,.cpp,.mm}'
       proto.public_header_files = 'Services/Protobuf/Proto/include/*.h'
       proto.requires_arc = false
-      proto.dependency 'Protobuf', '>= 3.22.0'
+      proto.dependency 'Protobuf', '~> 3.27'
     end
   end
   

--- a/GrowingAutotrackerCore/Autotrack/UIAlertController+GrowingAutotracker.h
+++ b/GrowingAutotrackerCore/Autotrack/UIAlertController+GrowingAutotracker.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)growing_dismissAnimated:(BOOL)animated
                  triggeringAction:(UIAlertAction *)action
-    triggeredByPopoverDimmingView:(UIView *)view
+    triggeredByPopoverDimmingView:(BOOL)isTriggeredByPopoverDimmingView
                 dismissCompletion:(id)completion;
 
 + (nullable UIAlertAction *)growing_actionForActionView:(UIView *)actionView;

--- a/GrowingAutotrackerCore/Autotrack/UIAlertController+GrowingAutotracker.m
+++ b/GrowingAutotrackerCore/Autotrack/UIAlertController+GrowingAutotracker.m
@@ -34,13 +34,15 @@
 
 - (void)growing_dismissAnimated:(BOOL)animated
                  triggeringAction:(UIAlertAction *)action
-    triggeredByPopoverDimmingView:(UIView *)view
+    triggeredByPopoverDimmingView:(BOOL)isTriggeredByPopoverDimmingView
                 dismissCompletion:(id)completion {
-    [self growing_sendClickEventForAction:action];
+    if (completion) {
+        [self growing_sendClickEventForAction:action];
+    }
 
     [self growing_dismissAnimated:animated
                      triggeringAction:action
-        triggeredByPopoverDimmingView:view
+        triggeredByPopoverDimmingView:isTriggeredByPopoverDimmingView
                     dismissCompletion:completion];
 }
 

--- a/GrowingTrackerCore/Network/GrowingNetworkInterfaceManager.m
+++ b/GrowingTrackerCore/Network/GrowingNetworkInterfaceManager.m
@@ -112,11 +112,7 @@
 
 - (GrowingNetworkReachabilityStatus)currentStatus {
     GrowingNetworkReachabilityStatus reachabilityStatus = GrowingNetworkReachabilityUndetermined;
-#if Growing_OS_VISION
-    if (1) {  // if (@available(visionOS 1.0, *)) {
-#else
     if (@available(iOS 12.0, macCatalyst 13.0, macOS 10.14, tvOS 12.0, watchOS 6.0, *)) {
-#endif
         reachabilityStatus = self.monitor.reachabilityStatus;
     } else {
         reachabilityStatus = self.internetReachability.reachabilityStatus;
@@ -126,11 +122,7 @@
 }
 
 - (void)monitorInitialize {
-#if Growing_OS_VISION
-    if (1) {  // if (@available(visionOS 1.0, *)) {
-#else
     if (@available(iOS 12.0, macCatalyst 13.0, macOS 10.14, tvOS 12.0, watchOS 6.0, *)) {
-#endif
         _monitor = [GrowingNetworkPathMonitor monitorWithQueue:_monitorQueue];
     } else {
         _internetReachability = [GrowingReachability reachabilityForInternetConnection];
@@ -138,11 +130,7 @@
 }
 
 - (void)startMonitor {
-#if Growing_OS_VISION
-    if (1) {  // if (@available(visionOS 1.0, *)) {
-#else
     if (@available(iOS 12.0, macCatalyst 13.0, macOS 10.14, tvOS 12.0, watchOS 6.0, *)) {
-#endif
         [_monitor startMonitor];
     } else {
         [_internetReachability startNotifier];

--- a/GrowingTrackerCore/Network/GrowingNetworkPathMonitor.m
+++ b/GrowingTrackerCore/Network/GrowingNetworkPathMonitor.m
@@ -33,11 +33,7 @@
 - (instancetype)initWithQueue:(dispatch_queue_t)monitorQueue {
     if (self = [super init]) {
         _reachabilityStatus = GrowingNetworkReachabilityUndetermined;
-#if Growing_OS_VISION
-        if (1) {  // if (@available(visionOS 1.0, *)) {
-#else
         if (@available(iOS 12.0, macCatalyst 13.0, macOS 10.14, tvOS 12.0, watchOS 6.0, *)) {
-#endif
             _monitor = nw_path_monitor_create();
             nw_path_monitor_set_queue(_monitor, monitorQueue);
 
@@ -64,31 +60,19 @@
 }
 
 - (void)startMonitor {
-#if Growing_OS_VISION
-    if (1) {  // if (@available(visionOS 1.0, *)) {
-#else
     if (@available(iOS 12.0, macCatalyst 13.0, macOS 10.14, tvOS 12.0, watchOS 6.0, *)) {
-#endif
         nw_path_monitor_start(self.monitor);
     }
 }
 
 - (void)stopMonitor {
-#if Growing_OS_VISION
-    if (1) {  // if (@available(visionOS 1.0, *)) {
-#else
     if (@available(iOS 12.0, macCatalyst 13.0, macOS 10.14, tvOS 12.0, watchOS 6.0, *)) {
-#endif
         nw_path_monitor_cancel(self.monitor);
     }
 }
 
-#if Growing_OS_VISION
-- (GrowingNetworkReachabilityStatus)reachabilityStatusForPath:(nw_path_t)path {
-#else
 - (GrowingNetworkReachabilityStatus)reachabilityStatusForPath:(nw_path_t)path
     API_AVAILABLE(ios(12.0), tvos(12.0), macos(10.14), watchos(6.0)) {
-#endif
     nw_path_status_t status = nw_path_get_status(path);
     if (status != nw_path_status_satisfied) {
         return GrowingNetworkReachabilityNotReachable;
@@ -109,11 +93,7 @@
     return GrowingNetworkReachabilityUndetermined;
 }
 
-#if Growing_OS_VISION
-- (void)reachabilityPathChanged:(nw_path_t)path {
-#else
 - (void)reachabilityPathChanged:(nw_path_t)path API_AVAILABLE(ios(12.0), tvos(12.0), macos(10.14), watchos(6.0)) {
-#endif
     GrowingNetworkReachabilityStatus status = [self reachabilityStatusForPath:path];
     if (self.reachabilityStatus != status) {
         self.reachabilityStatus = status;

--- a/GrowingTrackerCore/Utils/GrowingArgumentChecker.m
+++ b/GrowingTrackerCore/Utils/GrowingArgumentChecker.m
@@ -83,6 +83,9 @@
 + (NSDictionary<NSString *, NSString *> *_Nullable)serializableAttributes:(NSDictionary *)properties {
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     for (NSString *key in properties.allKeys) {
+        if (![key isKindOfClass:[NSString class]]) {
+            continue;
+        }
         id value = properties[key];
         if ([value isKindOfClass:[NSString class]]) {
             result[key] = value;

--- a/GrowingTrackerCore/Utils/GrowingKeyChainWrapper.m
+++ b/GrowingTrackerCore/Utils/GrowingKeyChainWrapper.m
@@ -31,11 +31,7 @@
     SecItemDelete((CFDictionaryRef)keychainQuery);
 
     // Add new object to search dictionary(Attention:the data format)
-#if Growing_OS_VISION
-    if (1) {  // if (@available(visionOS 1.0, *)) {
-#else
     if (@available(iOS 11.0, macCatalyst 13.1, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-#endif
         NSData *data = [NSKeyedArchiver archivedDataWithRootObject:value requiringSecureCoding:YES error:nil];
         [keychainQuery setObject:data forKey:(id)kSecValueData];
     } else {
@@ -65,11 +61,7 @@
     CFDataRef keyData = NULL;
     if (SecItemCopyMatching((CFDictionaryRef)keychainQuery, (CFTypeRef *)&keyData) == noErr) {
         @try {
-#if Growing_OS_VISION
-            if (1) {  // if (@available(visionOS 1.0, *)) {
-#else
             if (@available(iOS 11.0, macCatalyst 13.1, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-#endif
                 ret = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSString class]
                                                         fromData:(__bridge NSData *)keyData
                                                            error:nil];

--- a/Modules/ImpressionTrack/Public/UIView+GrowingImpression.h
+++ b/Modules/ImpressionTrack/Public/UIView+GrowingImpression.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param attributes 自定义属性
  */
 - (void)growingTrackImpression:(NSString *)eventName
-                    attributes:(NSDictionary<NSString *, NSString *> *_Nullable)attributes
+                    attributes:(NSDictionary<NSString *, id> *_Nullable)attributes
     NS_SWIFT_NAME(trackImp(_:attributes:))
         NS_EXTENSION_UNAVAILABLE("ImpressionTrack is not supported for iOS extensions.");
 

--- a/Modules/ImpressionTrack/UIView+GrowingImpressionInternal.m
+++ b/Modules/ImpressionTrack/UIView+GrowingImpressionInternal.m
@@ -111,8 +111,7 @@
     [self growingTrackImpression:eventName attributes:nil];
 }
 
-- (void)growingTrackImpression:(NSString *)eventName
-                    attributes:(NSDictionary<NSString *, id> *_Nullable)attributes {
+- (void)growingTrackImpression:(NSString *)eventName attributes:(NSDictionary<NSString *, id> *_Nullable)attributes {
     if (eventName.length == 0) {
         return;
     }

--- a/Modules/ImpressionTrack/UIView+GrowingImpressionInternal.m
+++ b/Modules/ImpressionTrack/UIView+GrowingImpressionInternal.m
@@ -112,7 +112,7 @@
 }
 
 - (void)growingTrackImpression:(NSString *)eventName
-                    attributes:(NSDictionary<NSString *, NSString *> *_Nullable)attributes {
+                    attributes:(NSDictionary<NSString *, id> *_Nullable)attributes {
     if (eventName.length == 0) {
         return;
     }


### PR DESCRIPTION
* imp 模块中，attributes 的类型也从 `[String: String]` 改为 `[String: Any]`
* 修复使用非字符串键设置动态通用属性时崩溃，如下：
```objc
[GrowingAutotracker setDynamicGeneralPropsGenerator:^NSDictionary<NSString *,id> * _Nonnull{
    return @{@1:@"1"};
}];
```
* 删除不必要的条件代码，这是由于 `@available(xxx, xxx, *)` 中 `*` 就代表其他平台，且 `API_AVAILABLE` 等价于 `@available(xxx, xxx, *)`。无需再使用宏判断 visionOS 平台
* ANLSPI-18506 修复在 iPad 上弹出的 actionSheet，通过点击变暗的背景视图 dismiss 会崩溃；同时，修复在 iOS 上该操作触发了 3 个 `VIEW_CLICK` 事件，现改为 2 个 (1 个为内部手势触发，1 个为 Cancel Action 触发)
* Google/Protobuf 3.27.0 已于近日发版，添加了 visionOS 平台 Cocoapods 集成支持，本 SDK 也跟进该平台的 Cocoapods 集成支持