### PR TITLE
fix: add DEFINES_MODULE to pod_target_xcconfig in order to avoid compile error when without module map

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,71 +1,71 @@
 PODS:
-  - GrowingAnalytics-cdp/Autotracker (3.8.4):
-    - GrowingAnalytics/AutotrackerCore (= 3.8.4)
-    - GrowingAnalytics/DefaultServices (= 3.8.4)
-    - GrowingAnalytics/Hybrid (= 3.8.4)
-    - GrowingAnalytics/MobileDebugger (= 3.8.4)
-    - GrowingAnalytics/WebCircle (= 3.8.4)
-  - GrowingAnalytics-cdp/Tracker (3.8.4):
-    - GrowingAnalytics/DefaultServices (= 3.8.4)
-    - GrowingAnalytics/MobileDebugger (= 3.8.4)
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/Advert (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/APM (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
+  - GrowingAnalytics-cdp/Autotracker (3.8.5):
+    - GrowingAnalytics/AutotrackerCore (= 3.8.5)
+    - GrowingAnalytics/DefaultServices (= 3.8.5)
+    - GrowingAnalytics/Hybrid (= 3.8.5)
+    - GrowingAnalytics/MobileDebugger (= 3.8.5)
+    - GrowingAnalytics/WebCircle (= 3.8.5)
+  - GrowingAnalytics-cdp/Tracker (3.8.5):
+    - GrowingAnalytics/DefaultServices (= 3.8.5)
+    - GrowingAnalytics/MobileDebugger (= 3.8.5)
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/Advert (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/APM (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
     - GrowingAPM/Core
-  - GrowingAnalytics/Autotracker (3.8.4):
-    - GrowingAnalytics/AutotrackerCore (= 3.8.4)
-    - GrowingAnalytics/DefaultServices (= 3.8.4)
-    - GrowingAnalytics/Hybrid (= 3.8.4)
-    - GrowingAnalytics/MobileDebugger (= 3.8.4)
-    - GrowingAnalytics/WebCircle (= 3.8.4)
-  - GrowingAnalytics/AutotrackerCore (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
+  - GrowingAnalytics/Autotracker (3.8.5):
+    - GrowingAnalytics/AutotrackerCore (= 3.8.5)
+    - GrowingAnalytics/DefaultServices (= 3.8.5)
+    - GrowingAnalytics/Hybrid (= 3.8.5)
+    - GrowingAnalytics/MobileDebugger (= 3.8.5)
+    - GrowingAnalytics/WebCircle (= 3.8.5)
+  - GrowingAnalytics/AutotrackerCore (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
     - GrowingUtils/AutotrackerCore (~> 1.2.3)
-  - GrowingAnalytics/Compression (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/Database (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/DefaultServices (3.8.4):
-    - GrowingAnalytics/Compression (= 3.8.4)
-    - GrowingAnalytics/Database (= 3.8.4)
-    - GrowingAnalytics/Encryption (= 3.8.4)
-    - GrowingAnalytics/Network (= 3.8.4)
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/Encryption (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/Hybrid (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/MobileDebugger (3.8.4):
-    - GrowingAnalytics/Screenshot (= 3.8.4)
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-    - GrowingAnalytics/WebSocket (= 3.8.4)
-  - GrowingAnalytics/Network (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/Protobuf (3.8.4):
-    - GrowingAnalytics/Database (= 3.8.4)
-    - GrowingAnalytics/Protobuf/Proto (= 3.8.4)
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/Protobuf/Proto (3.8.4):
-    - GrowingAnalytics/Database (= 3.8.4)
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
+  - GrowingAnalytics/Compression (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/Database (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/DefaultServices (3.8.5):
+    - GrowingAnalytics/Compression (= 3.8.5)
+    - GrowingAnalytics/Database (= 3.8.5)
+    - GrowingAnalytics/Encryption (= 3.8.5)
+    - GrowingAnalytics/Network (= 3.8.5)
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/Encryption (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/Hybrid (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/MobileDebugger (3.8.5):
+    - GrowingAnalytics/Screenshot (= 3.8.5)
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+    - GrowingAnalytics/WebSocket (= 3.8.5)
+  - GrowingAnalytics/Network (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/Protobuf (3.8.5):
+    - GrowingAnalytics/Database (= 3.8.5)
+    - GrowingAnalytics/Protobuf/Proto (= 3.8.5)
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/Protobuf/Proto (3.8.5):
+    - GrowingAnalytics/Database (= 3.8.5)
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
     - Protobuf
-  - GrowingAnalytics/Screenshot (3.8.4):
+  - GrowingAnalytics/Screenshot (3.8.5):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Tracker (3.8.4):
-    - GrowingAnalytics/DefaultServices (= 3.8.4)
-    - GrowingAnalytics/MobileDebugger (= 3.8.4)
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
-  - GrowingAnalytics/TrackerCore (3.8.4):
+  - GrowingAnalytics/Tracker (3.8.5):
+    - GrowingAnalytics/DefaultServices (= 3.8.5)
+    - GrowingAnalytics/MobileDebugger (= 3.8.5)
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
+  - GrowingAnalytics/TrackerCore (3.8.5):
     - GrowingUtils/TrackerCore (~> 1.2.3)
-  - GrowingAnalytics/WebCircle (3.8.4):
-    - GrowingAnalytics/AutotrackerCore (= 3.8.4)
-    - GrowingAnalytics/Hybrid (= 3.8.4)
-    - GrowingAnalytics/Screenshot (= 3.8.4)
-    - GrowingAnalytics/WebSocket (= 3.8.4)
-  - GrowingAnalytics/WebSocket (3.8.4):
-    - GrowingAnalytics/TrackerCore (= 3.8.4)
+  - GrowingAnalytics/WebCircle (3.8.5):
+    - GrowingAnalytics/AutotrackerCore (= 3.8.5)
+    - GrowingAnalytics/Hybrid (= 3.8.5)
+    - GrowingAnalytics/Screenshot (= 3.8.5)
+    - GrowingAnalytics/WebSocket (= 3.8.5)
+  - GrowingAnalytics/WebSocket (3.8.5):
+    - GrowingAnalytics/TrackerCore (= 3.8.5)
   - GrowingAPM (1.0.1):
     - GrowingAPM/Core (= 1.0.1)
     - GrowingAPM/CrashMonitor (= 1.0.1)
@@ -161,8 +161,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: ac5a35051ae61aec182d11da12e89ec98ea4e807
-  GrowingAnalytics-cdp: 0b0b98b7a3b116ae05778ee29b4aac76d1b5fc03
+  GrowingAnalytics: 0f45c3be51d1daaeabc98025586c448922c8ae72
+  GrowingAnalytics-cdp: 08c85179967c06c36e7377731e2fc7aefc8c470f
   GrowingAPM: 3c4de0384935b654e6798b95606f47883a99418b
   GrowingToolsKit: 53160d19690da0b78e04a9242abde7af86442922
   GrowingUtils: 68aee2c96849bf9b674740503da30c2da468e79d

--- a/GrowingAnalytics-cdp.podspec
+++ b/GrowingAnalytics-cdp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics-cdp'
-  s.version          = '3.8.4'
+  s.version          = '3.8.5'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics-cdp基于GrowingAnalytics，同样具备自动采集基本的用户行为事件，比如访问和行为数据等。

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -14,7 +14,7 @@ GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和�
   s.ios.framework = 'WebKit'
   s.requires_arc = true
   s.default_subspec = "Autotracker"
-  s.pod_target_xcconfig = { 'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"' }
 
   s.subspec 'Autotracker' do |autotracker|
     autotracker.ios.deployment_target = '10.0'

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.8.4'
+  s.version          = '3.8.5'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -38,8 +38,8 @@
 #import "GrowingTrackerCore/Utils/GrowingDeviceInfo.h"
 #import "GrowingULAppLifecycle.h"
 
-NSString *const GrowingTrackerVersionName = @"3.8.4";
-const int GrowingTrackerVersionCode = 30804;
+NSString *const GrowingTrackerVersionName = @"3.8.5";
+const int GrowingTrackerVersionCode = 30805;
 
 @interface GrowingRealTracker ()
 

--- a/Modules/Protobuf/Catagory/GrowingBaseEvent+Protobuf.m
+++ b/Modules/Protobuf/Catagory/GrowingBaseEvent+Protobuf.m
@@ -68,7 +68,7 @@
         __strong typeof(weakSelf) self = weakSelf;
         SEL selector = NSSelectorFromString(selectorString);
         if ([self respondsToSelector:selector]) {
-            int32_t result = ((int32_t(*)(id, SEL))objc_msgSend)(self, selector);
+            int32_t result = ((int32_t (*)(id, SEL))objc_msgSend)(self, selector);
             return result > 0 ? result : 0;
         }
         return 0;
@@ -78,7 +78,7 @@
         __strong typeof(weakSelf) self = weakSelf;
         SEL selector = NSSelectorFromString(selectorString);
         if ([self respondsToSelector:selector]) {
-            int64_t result = ((int64_t(*)(id, SEL))objc_msgSend)(self, selector);
+            int64_t result = ((int64_t (*)(id, SEL))objc_msgSend)(self, selector);
             return result > 0 ? result : (int64_t)0;
         }
         return (int64_t)0;


### PR DESCRIPTION
## PR 内容
**Objective-C 项目**，如果没有使用 `use_frameworks! :linkage => :static/dynamic、use_modular_headers!` 等配置进行模块化 pod，则会报错 **Module 'GrowingAnalytics' not found**
![image](https://github.com/user-attachments/assets/1ad26007-b401-45a5-bb05-75e9beadaf1a)

前情提要
* #290 