### PR TITLE
fix: replace deprecated api from swift-protobuf

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
-            from: "1.21.0"
+            from: "1.27.0"
         ),
     ],
     targets: [

--- a/Services/SwiftProtobuf/SwiftProtobuf.swift
+++ b/Services/SwiftProtobuf/SwiftProtobuf.swift
@@ -36,7 +36,7 @@ public class SwiftProtobufWrapper: NSObject {
     @objc(parseFromData:)
     public static func parse(from data: Data) -> SwiftProtobufWrapper? {
         do {
-            let dto = try EventDto(serializedData: data)
+            let dto = try EventDto(serializedBytes: data)
             return SwiftProtobufWrapper(dto)
         } catch {
             return nil
@@ -171,7 +171,7 @@ public extension SwiftProtobufWrapper {
     @objc(convertProtobufDataToJsonArray:)
     static func convertProtobufDataToJsonArray(from data: Data) -> [[String: AnyObject]]? {
         do {
-            let list = try EventList(serializedData: data)
+            let list = try EventList(serializedBytes: data)
             var array = [[String: AnyObject]]()
             for dto in list.values {
                 let jsonData = try dto.jsonUTF8Data()


### PR DESCRIPTION
https://github.com/apple/swift-protobuf/blob/ebc7251dd5b37f627c93698e4374084d98409633/Sources/SwiftProtobuf/Message%2BBinaryAdditions_Data.swift#L34
```swift
@inlinable
@available(*, deprecated, renamed: "init(serializedBytes:extensions:partial:options:)")
public init(
   serializedData data: Data,
   extensions: (any ExtensionMap)? = nil,
    partial: Bool = false,
    options: BinaryDecodingOptions = BinaryDecodingOptions()
) throws {
    self.init()
    try merge(serializedBytes: data, extensions: extensions, partial: partial, options: options)
}
```

https://github.com/apple/swift-protobuf/blob/ebc7251dd5b37f627c93698e4374084d98409633/Sources/SwiftProtobuf/SwiftProtobufContiguousBytes.swift#L57
```
extension Data: SwiftProtobufContiguousBytes {}
```