### PR TITLE
feat(ads): ANLSPI-22249 CAID support

### DIFF
--- a/Example/Example/AppDelegate.m
+++ b/Example/Example/AppDelegate.m
@@ -57,6 +57,16 @@
         }
         NSLog(@"deepLinkCallback params = %@, processTime = %f", params, processTime);
     };
+    configuration.CAIDFetchBlock = ^(void (^ _Nonnull didCompleteBlock)(NSString * _Nonnull)) {
+        // 模拟异步请求
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            NSString *caid =  @"["
+            @"{\"caid\":\"507b36cb169864220bc22a8c522532fa\",\"version\":\"20220111\"},"
+            @"{\"caid\":\"e18a100398425c5026591525e844f7a7\",\"version\":\"20230330\"}"
+            @"]";
+            didCompleteBlock(caid);
+        });
+    };
 #endif
     
 #if defined(SDKAPMMODULE)

--- a/GrowingTrackerCore/GrowingTrackConfiguration.m
+++ b/GrowingTrackerCore/GrowingTrackConfiguration.m
@@ -31,6 +31,7 @@ NSString *const kGrowingDefaultABTestingServerHost = @"https://ab.growingio.com"
 @property (nonatomic, copy) NSString *deepLinkHost;
 @property (nonatomic, copy) id deepLinkCallback;
 @property (nonatomic, assign) BOOL readClipboardEnabled;
+@property (nonatomic, copy) id CAIDFetchBlock;
 
 // APM
 @property (nonatomic, copy) NSObject *APMConfig;
@@ -72,6 +73,7 @@ NSString *const kGrowingDefaultABTestingServerHost = @"https://ab.growingio.com"
         _deepLinkHost = kGrowingDefaultDeepLinkHost;
         _deepLinkCallback = nil;
         _readClipboardEnabled = YES;
+        _CAIDFetchBlock = nil;
 
         // APM
         _APMConfig = nil;
@@ -119,6 +121,7 @@ NSString *const kGrowingDefaultABTestingServerHost = @"https://ab.growingio.com"
     configuration->_deepLinkHost = [_deepLinkHost copy];
     configuration->_deepLinkCallback = [_deepLinkCallback copy];
     configuration->_readClipboardEnabled = _readClipboardEnabled;
+    configuration->_CAIDFetchBlock = [_CAIDFetchBlock copy];
 
     // APM
     configuration->_APMConfig = [_APMConfig copy];

--- a/Modules/Advertising/CAID/GrowingCAIDFetcher.h
+++ b/Modules/Advertising/CAID/GrowingCAIDFetcher.h
@@ -1,0 +1,30 @@
+//
+//  GrowingCAIDFetcher.h
+//  GrowingAnalytics
+//
+//  Created by YoloMao on 2024/10/17.
+//  Copyright (C) 2024 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GrowingCAIDFetcher : NSObject
+
++ (void)startFetch;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/Advertising/CAID/GrowingCAIDFetcher.m
+++ b/Modules/Advertising/CAID/GrowingCAIDFetcher.m
@@ -1,0 +1,190 @@
+//
+//  GrowingCAIDFetcher.m
+//  GrowingAnalytics
+//
+//  Created by YoloMao on 2024/10/17.
+//  Copyright (C) 2024 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import "Modules/Advertising/CAID/GrowingCAIDFetcher.h"
+#import "Modules/Advertising/Event/GrowingAdEventType.h"
+#import "Modules/Advertising/Public/GrowingAdvertising.h"
+
+#import "GrowingTrackerCore/Event/GrowingEventManager.h"
+#import "GrowingTrackerCore/Manager/GrowingConfigurationManager.h"
+#import "GrowingTrackerCore/Thirdparty/Logger/GrowingLogger.h"
+
+#import <objc/runtime.h>
+#import <pthread.h>
+
+typedef NS_ENUM(NSUInteger, GrowingCAIDFetcherStatus) {
+    GrowingCAIDFetcherStatusDenied = 1,  // 未配置CAID获取接口
+    GrowingCAIDFetcherStatusFailure,     // 获取CAID标识符失败(超时)
+    GrowingCAIDFetcherStatusFetching,    // 正在获取CAID标识符
+    GrowingCAIDFetcherStatusSuccess,     // 获取CAID标识符成功
+};
+
+static CGFloat const kGrowingCAIDFetcherDefaultTimeOut = 5.0f;
+static pthread_rwlock_t _lock = PTHREAD_RWLOCK_INITIALIZER;
+
+@interface GrowingCAIDFetcher () <GrowingEventInterceptor>
+
+@property (class, nonatomic, assign) GrowingCAIDFetcherStatus status;
+@property (class, nonatomic, nullable, copy) NSString *caid;
+
+@end
+
+@implementation GrowingCAIDFetcher
+
+#pragma mark - Init
+
++ (instancetype)sharedInstance {
+    static GrowingCAIDFetcher *instance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[GrowingCAIDFetcher alloc] init];
+    });
+    return instance;
+}
+
+#pragma mark - GrowingEventInterceptor
+
+- (NSArray *)growingEventManagerEventsWillSend:(NSArray<id<GrowingEventPersistenceProtocol>> *)events
+                                       channel:(GrowingEventChannel *)channel {
+    if (channel.eventTypes.count == 0 || [channel.eventTypes indexOfObject:GrowingEventTypeActivate] == NSNotFound) {
+        return events;
+    }
+
+    NSMutableArray<id <GrowingEventPersistenceProtocol>> *activates = @[].mutableCopy;
+    for (id<GrowingEventPersistenceProtocol> event in events) {
+        if ([event.eventType isEqualToString:GrowingEventTypeActivate]) {
+            [activates addObject:event];
+        }
+    }
+    if (activates.count == 0) {
+        return events;
+    }
+
+    if (GrowingCAIDFetcher.status == GrowingCAIDFetcherStatusFetching) {
+        // CAID 还在获取中，activate 需延迟上传
+        NSMutableArray *array = [NSMutableArray arrayWithArray:events];
+        [array removeObjectsInArray:activates];
+        return array;
+    } else {
+        if (GrowingCAIDFetcher.caid.length > 0) {
+            NSString *caid = GrowingCAIDFetcher.caid.copy;
+            for (id<GrowingEventPersistenceProtocol> event in activates) {
+                [event appendExtraParams:@{@"CAID": caid}];
+            }
+        }
+    }
+
+    return events;
+}
+
+#pragma mark - Public Method
+
++ (void)startFetch {
+    if (self.status == GrowingCAIDFetcherStatusFetching) {
+        return;
+    }
+
+    GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
+    if (!trackConfiguration.dataCollectionEnabled) {
+        GIOLogDebug(@"[GrowingAdvertising] CAIDFetcher - dataCollectionEnabled is NO");
+        self.status = GrowingCAIDFetcherStatusDenied;
+        return;
+    }
+    
+    if (!trackConfiguration.CAIDFetchBlock) {
+        GIOLogDebug(@"[GrowingAdvertising] CAIDFetcher - CAIDFetchBlock is nil");
+        self.status = GrowingCAIDFetcherStatusDenied;
+        return;
+    }
+
+    [[GrowingEventManager sharedInstance] addInterceptor:[GrowingCAIDFetcher sharedInstance]];
+    CGFloat timeOut = kGrowingCAIDFetcherDefaultTimeOut;
+    GIOLogDebug(@"[GrowingAdvertising] CAIDFetcher start fetch with time out %.2f sec", timeOut);
+    self.status = GrowingCAIDFetcherStatusFetching;
+    [[GrowingCAIDFetcher sharedInstance] fetchCAID];
+    
+    dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeOut * NSEC_PER_SEC));
+    dispatch_after(delayTime, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        if (self.status != GrowingCAIDFetcherStatusFetching) {
+            return;
+        }
+        GrowingCAIDFetcher.status = GrowingCAIDFetcherStatusFailure;
+        GIOLogError(@"[GrowingAdvertising] CAIDFetcher error: time is out");
+    });
+}
+
+#pragma mark - Private Method
+
+- (void)fetchCAID {
+    GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
+    trackConfiguration.CAIDFetchBlock(^(NSString * _Nonnull CAID) {
+        if (CAID.length > 0) {
+            GrowingCAIDFetcher.caid = CAID;
+            GrowingCAIDFetcher.status = GrowingCAIDFetcherStatusSuccess;
+        } else {
+            GrowingCAIDFetcher.status = GrowingCAIDFetcherStatusFailure;
+        }
+    });
+}
+
+#pragma mark - Setter & Getter
+
++ (GrowingCAIDFetcherStatus)status {
+    pthread_rwlock_rdlock(&_lock);
+    int status = ((NSNumber *)objc_getAssociatedObject(self, _cmd)).intValue;
+    pthread_rwlock_unlock(&_lock);
+    return status;
+}
+
++ (void)setStatus:(GrowingCAIDFetcherStatus)status {
+    if (self.status == status) {
+        return;
+    }
+
+    pthread_rwlock_wrlock(&_lock);
+    objc_setAssociatedObject(self, @selector(status), @(status), OBJC_ASSOCIATION_ASSIGN);
+    pthread_rwlock_unlock(&_lock);
+    GIOLogDebug(@"[GrowingAdvertising] CAIDFetcher fetch status change to %@", [self statusDescription]);
+}
+
++ (NSString *)statusDescription {
+    switch (self.status) {
+        case GrowingCAIDFetcherStatusDenied:
+            return @"denied";
+        case GrowingCAIDFetcherStatusFetching:
+            return @"fetching";
+        case GrowingCAIDFetcherStatusSuccess:
+            return @"success";
+        case GrowingCAIDFetcherStatusFailure:
+            return @"failure";
+        default:
+            return @"";
+    }
+}
+
++ (nullable NSString *)caid {
+    return objc_getAssociatedObject(self, _cmd);
+}
+
++ (void)setCaid:(NSString *)caid {
+    objc_setAssociatedObject(self, @selector(caid), caid, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    GIOLogDebug(@"[GrowingAdvertising] CAIDFetcher set CAID = %@", caid);
+}
+
+@end

--- a/Modules/Advertising/CAID/GrowingCAIDFetcher.m
+++ b/Modules/Advertising/CAID/GrowingCAIDFetcher.m
@@ -66,7 +66,7 @@ static pthread_rwlock_t _lock = PTHREAD_RWLOCK_INITIALIZER;
         return events;
     }
 
-    NSMutableArray<id <GrowingEventPersistenceProtocol>> *activates = @[].mutableCopy;
+    NSMutableArray<id<GrowingEventPersistenceProtocol>> *activates = @[].mutableCopy;
     for (id<GrowingEventPersistenceProtocol> event in events) {
         if ([event.eventType isEqualToString:GrowingEventTypeActivate]) {
             [activates addObject:event];
@@ -106,7 +106,7 @@ static pthread_rwlock_t _lock = PTHREAD_RWLOCK_INITIALIZER;
         self.status = GrowingCAIDFetcherStatusDenied;
         return;
     }
-    
+
     if (!trackConfiguration.CAIDFetchBlock) {
         GIOLogDebug(@"[GrowingAdvertising] CAIDFetcher - CAIDFetchBlock is nil");
         self.status = GrowingCAIDFetcherStatusDenied;
@@ -118,7 +118,7 @@ static pthread_rwlock_t _lock = PTHREAD_RWLOCK_INITIALIZER;
     GIOLogDebug(@"[GrowingAdvertising] CAIDFetcher start fetch with time out %.2f sec", timeOut);
     self.status = GrowingCAIDFetcherStatusFetching;
     [[GrowingCAIDFetcher sharedInstance] fetchCAID];
-    
+
     dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeOut * NSEC_PER_SEC));
     dispatch_after(delayTime, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         if (self.status != GrowingCAIDFetcherStatusFetching) {
@@ -133,7 +133,7 @@ static pthread_rwlock_t _lock = PTHREAD_RWLOCK_INITIALIZER;
 
 - (void)fetchCAID {
     GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
-    trackConfiguration.CAIDFetchBlock(^(NSString * _Nonnull CAID) {
+    trackConfiguration.CAIDFetchBlock(^(NSString *_Nonnull CAID) {
         if (CAID.length > 0) {
             GrowingCAIDFetcher.caid = CAID;
             GrowingCAIDFetcher.status = GrowingCAIDFetcherStatusSuccess;

--- a/Modules/Advertising/GrowingAdvertising.m
+++ b/Modules/Advertising/GrowingAdvertising.m
@@ -173,7 +173,7 @@ NSString *const GrowingAdvertisingErrorDomain = @"com.growingio.advertising";
     if ([self SDKDoNotTrack]) {
         return NO;
     }
-    
+
     [GrowingCAIDFetcher startFetch];
 
     // Universal Link 短链
@@ -302,7 +302,7 @@ NSString *const GrowingAdvertisingErrorDomain = @"com.growingio.advertising";
         if ([self SDKDoNotTrack]) {
             return;
         }
-        
+
         [GrowingCAIDFetcher startFetch];
 
         GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;

--- a/Modules/Advertising/GrowingAdvertising.m
+++ b/Modules/Advertising/GrowingAdvertising.m
@@ -19,6 +19,7 @@
 
 #import "Modules/Advertising/Public/GrowingAdvertising.h"
 #import "Modules/Advertising/AppleSearchAds/GrowingAsaFetcher.h"
+#import "Modules/Advertising/CAID/GrowingCAIDFetcher.h"
 #import "Modules/Advertising/Event/GrowingActivateEvent.h"
 #import "Modules/Advertising/Event/GrowingAdEventType.h"
 #import "Modules/Advertising/Request/GrowingAdPreRequest.h"
@@ -172,6 +173,8 @@ NSString *const GrowingAdvertisingErrorDomain = @"com.growingio.advertising";
     if ([self SDKDoNotTrack]) {
         return NO;
     }
+    
+    [GrowingCAIDFetcher startFetch];
 
     // Universal Link 短链
     if ([GrowingAdUtils isShortChainUlink:url]) {
@@ -299,6 +302,8 @@ NSString *const GrowingAdvertisingErrorDomain = @"com.growingio.advertising";
         if ([self SDKDoNotTrack]) {
             return;
         }
+        
+        [GrowingCAIDFetcher startFetch];
 
         GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
         if ([GrowingAdUtils isActivateWrote]) {

--- a/Modules/Advertising/Public/GrowingAdvertising.h
+++ b/Modules/Advertising/Public/GrowingAdvertising.h
@@ -35,7 +35,7 @@ typedef void (^_Nullable GrowingAdDeepLinkCallback)(NSDictionary *_Nullable para
                                                     NSTimeInterval processTime,
                                                     NSError *_Nullable error);
 
-typedef void (^_Nullable GrowingAdCAIDFetchBlock)(void(^didCompleteBlock)(NSString *CAID));
+typedef void (^_Nullable GrowingAdCAIDFetchBlock)(void (^didCompleteBlock)(NSString *CAID));
 
 NS_EXTENSION_UNAVAILABLE("Advertising is not supported for iOS extensions.")
 NS_SWIFT_NAME(Advertising)

--- a/Modules/Advertising/Public/GrowingAdvertising.h
+++ b/Modules/Advertising/Public/GrowingAdvertising.h
@@ -35,6 +35,8 @@ typedef void (^_Nullable GrowingAdDeepLinkCallback)(NSDictionary *_Nullable para
                                                     NSTimeInterval processTime,
                                                     NSError *_Nullable error);
 
+typedef void (^_Nullable GrowingAdCAIDFetchBlock)(void(^didCompleteBlock)(NSString *CAID));
+
 NS_EXTENSION_UNAVAILABLE("Advertising is not supported for iOS extensions.")
 NS_SWIFT_NAME(Advertising)
 @interface GrowingAdvertising : NSObject <GrowingModuleProtocol>
@@ -60,6 +62,7 @@ NS_SWIFT_NAME(Advertising)
 @property (nonatomic, copy) NSString *deepLinkHost;
 @property (nonatomic, copy) GrowingAdDeepLinkCallback deepLinkCallback;
 @property (nonatomic, assign) BOOL readClipboardEnabled;
+@property (nonatomic, copy) GrowingAdCAIDFetchBlock CAIDFetchBlock;
 
 @end
 


### PR DESCRIPTION
支持广协 CAID 归因，需要在 SDK 初始化时，通过配置项 `configuration.CAIDFetchBlock` 传入获取 CAID 操作(需保证每次获取最新 CAID)，并在 block 最后调用 didCompleteBlock 传入获取到的 CAID JSON 字符串，示例如下：
```objc
configuration.CAIDFetchBlock = ^(void (^ _Nonnull didCompleteBlock)(NSString * _Nonnull)) {
    // 模拟异步请求
    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
        NSString *caid =  @"["
        @"{\"caid\":\"507b36cb169864220bc22a8c522532fa\",\"version\":\"20220111\"},"
        @"{\"caid\":\"e18a100398425c5026591525e844f7a7\",\"version\":\"20230330\"}"
        @"]";
        didCompleteBlock(caid);
    });
};
```
如果未调用 didCompleteBlock 或超时 5 秒，则此前生成的 ACTIVATE 事件将使用此前获取到的缓存在内存中的 CAID 事件属性(如果有)