### PR TITLE
fix: ANLSPI-26449 move to Xcode 16

### DIFF
--- a/.github/workflows/build_xcframework_manual.yml
+++ b/.github/workflows/build_xcframework_manual.yml
@@ -8,17 +8,9 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: macos-latest
+    runs-on: macos-15
 
-    steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-          
+    steps:    
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -5,17 +5,9 @@ on:
 
 jobs:
   publish:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-
       - uses: actions/checkout@v4
         
       - name: Deploy to Cocoapods

--- a/.github/workflows/cocoapods_beta.yml
+++ b/.github/workflows/cocoapods_beta.yml
@@ -13,18 +13,10 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: macos-15
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-            
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cocoapods_beta_manual.yml
+++ b/.github/workflows/cocoapods_beta_manual.yml
@@ -11,19 +11,11 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: macos-15
     # main 分支的发布请走正式流程，手动仅能发布其他分支的beta版本，用于测试
     if: ${{ github.ref != 'refs/heads/master' }}
     # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-            
+    steps: 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/code_format.yml
+++ b/.github/workflows/code_format.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   code-format:
     name: Code Format
-    runs-on: macos-latest
+    runs-on: macos-15
     if: ${{ github.actor != 'GIOSDK' }} # 禁止套娃
     steps:
       - name: Checkout

--- a/.github/workflows/draft_release_with_tag.yml
+++ b/.github/workflows/draft_release_with_tag.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Check if on master branch
@@ -18,14 +18,6 @@ jobs:
             echo "Not running on master branch"
             exit 1
           fi
-
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
           
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/draft_release_without_tag.yml
+++ b/.github/workflows/draft_release_without_tag.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Check if on master branch
@@ -18,14 +18,6 @@ jobs:
             echo "Not running on master branch"
             exit 1
           fi
-
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -21,10 +21,8 @@ jobs:
           tvOS,
           watchOS,
         ]
-        os: [macos-14, macos-15]
+        os: [macos-15]
         include:
-          - os: macos-14
-            xcode: Xcode_16.0
           - os: macos-15
             xcode: Xcode_16.2
           - target: iOS


### PR DESCRIPTION
https://developer.apple.com/news/?id=9s0rgdy9

Beginning April 24, 2025, apps uploaded to App Store Connect must be built with Xcode 16 or later using an SDK for iOS 18, iPadOS 18, tvOS 18, visionOS 2, or watchOS 11.