### PR TITLE
fix: ANLSPI-27507 remove using of deprecated api

### DIFF
--- a/Example/GrowingAnalyticsTests/TrackerCoreTests/SwizzleTests/GrowingSwizzleTest.m
+++ b/Example/GrowingAnalyticsTests/TrackerCoreTests/SwizzleTests/GrowingSwizzleTest.m
@@ -161,29 +161,6 @@ static void fooMethod(id obj, SEL _cmd) {
 
 @end
 
-@interface Growing_Swizzle_Proxy_XCTest2 : NSProxy
-
-@property (nonatomic, weak) id target;
-
-- (instancetype)initWithTarget:(id)target;
-
-- (void)delegateSelector;
-
-@end
-
-@implementation Growing_Swizzle_Proxy_XCTest2
-
-- (instancetype)initWithTarget:(id)target {
-    _target = target;
-    return self;
-}
-
-- (id)forwardingTargetForSelector:(SEL)aSelector {
-    return _target;
-}
-
-@end
-
 @interface GrowingULSwizzleTest : XCTestCase
 
 @property (nonatomic, strong) NSMutableString *swizzleString;
@@ -384,31 +361,15 @@ static void fooMethod(id obj, SEL _cmd) {
 
 - (void)test07GrowingULSwizzlerRealDelegate {
     // NSProxy
-    id proxy = nil;
-    id proxy1 = [[Growing_Swizzle_Proxy_XCTest alloc] initWithTarget:nil];
-    id proxy2 = [[Growing_Swizzle_Proxy_XCTest2 alloc] initWithTarget:proxy1];
+    id proxy = [[Growing_Swizzle_Proxy_XCTest alloc] initWithTarget:nil];
     {
-        XCTAssertNoThrow([GrowingULSwizzle realDelegate:proxy toSelector:@selector(delegateSelector)]);
-
         // proxy 本身实现了
-        id result = [GrowingULSwizzle realDelegate:proxy1 toSelector:@selector(delegateSelector)];
-        XCTAssertEqualObjects(proxy1, result);
-        XCTAssertTrue([GrowingULSwizzle realDelegateClass:((NSObject *)result).class
+        XCTAssertTrue([GrowingULSwizzle realDelegateClass:((NSObject *)proxy).class
                                         respondsToSelector:@selector(delegateSelector)]);
 
         // proxy 在 resolveInstanceMethod 增加了实现
-        id result2 = [GrowingULSwizzle realDelegate:proxy1 toSelector:@selector(delegateSelector2)];
-        XCTAssertEqualObjects(proxy1, result2);
-        XCTAssertTrue([GrowingULSwizzle realDelegateClass:((NSObject *)result2).class
+        XCTAssertTrue([GrowingULSwizzle realDelegateClass:((NSObject *)proxy).class
                                         respondsToSelector:@selector(delegateSelector2)]);
-    }
-
-    {
-        // proxy 在 forwardingTargetForSelector 转发给了另一个对象
-        id result = [GrowingULSwizzle realDelegate:proxy2 toSelector:@selector(delegateSelector)];
-        XCTAssertEqualObjects(proxy1, result);
-        XCTAssertTrue([GrowingULSwizzle realDelegateClass:((NSObject *)result).class
-                                        respondsToSelector:@selector(delegateSelector)]);
     }
 }
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,86 +1,86 @@
 PODS:
-  - GrowingAnalytics/ABTesting (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/Ads (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/APM (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
+  - GrowingAnalytics/ABTesting (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/Ads (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/APM (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
     - GrowingAPM/Core (~> 1.0.1)
-  - GrowingAnalytics/Autotracker (4.5.0):
-    - GrowingAnalytics/AutotrackerCore (= 4.5.0)
-    - GrowingAnalytics/DefaultServices (= 4.5.0)
-    - GrowingAnalytics/Hybrid (= 4.5.0)
-    - GrowingAnalytics/MobileDebugger (= 4.5.0)
-    - GrowingAnalytics/WebCircle (= 4.5.0)
-  - GrowingAnalytics/AutotrackerCore (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-    - GrowingUtils/AutotrackerCore (~> 1.2.3)
-  - GrowingAnalytics/Compression (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/Database (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/DefaultServices (4.5.0):
-    - GrowingAnalytics/Compression (= 4.5.0)
-    - GrowingAnalytics/Encryption (= 4.5.0)
-    - GrowingAnalytics/JSON (= 4.5.0)
-    - GrowingAnalytics/Network (= 4.5.0)
-    - GrowingAnalytics/Protobuf (= 4.5.0)
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/Encryption (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/Hybrid (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/ImpressionTrack (4.5.0):
-    - GrowingAnalytics/AutotrackerCore (= 4.5.0)
-  - GrowingAnalytics/JSON (4.5.0):
-    - GrowingAnalytics/Database (= 4.5.0)
-  - GrowingAnalytics/MobileDebugger (4.5.0):
-    - GrowingAnalytics/Screenshot (= 4.5.0)
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-    - GrowingAnalytics/WebSocket (= 4.5.0)
-  - GrowingAnalytics/Network (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/Protobuf (4.5.0):
-    - GrowingAnalytics/Database (= 4.5.0)
-    - GrowingAnalytics/Protobuf/Proto (= 4.5.0)
-  - GrowingAnalytics/Protobuf/Proto (4.5.0):
-    - GrowingAnalytics/Database (= 4.5.0)
+  - GrowingAnalytics/Autotracker (4.6.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.6.0)
+    - GrowingAnalytics/DefaultServices (= 4.6.0)
+    - GrowingAnalytics/Hybrid (= 4.6.0)
+    - GrowingAnalytics/MobileDebugger (= 4.6.0)
+    - GrowingAnalytics/WebCircle (= 4.6.0)
+  - GrowingAnalytics/AutotrackerCore (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+    - GrowingUtils/AutotrackerCore (~> 1.2.4)
+  - GrowingAnalytics/Compression (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/Database (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/DefaultServices (4.6.0):
+    - GrowingAnalytics/Compression (= 4.6.0)
+    - GrowingAnalytics/Encryption (= 4.6.0)
+    - GrowingAnalytics/JSON (= 4.6.0)
+    - GrowingAnalytics/Network (= 4.6.0)
+    - GrowingAnalytics/Protobuf (= 4.6.0)
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/Encryption (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/Hybrid (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/ImpressionTrack (4.6.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.6.0)
+  - GrowingAnalytics/JSON (4.6.0):
+    - GrowingAnalytics/Database (= 4.6.0)
+  - GrowingAnalytics/MobileDebugger (4.6.0):
+    - GrowingAnalytics/Screenshot (= 4.6.0)
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+    - GrowingAnalytics/WebSocket (= 4.6.0)
+  - GrowingAnalytics/Network (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/Protobuf (4.6.0):
+    - GrowingAnalytics/Database (= 4.6.0)
+    - GrowingAnalytics/Protobuf/Proto (= 4.6.0)
+  - GrowingAnalytics/Protobuf/Proto (4.6.0):
+    - GrowingAnalytics/Database (= 4.6.0)
     - Protobuf (~> 3.27)
-  - GrowingAnalytics/Screenshot (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/Tracker (4.5.0):
-    - GrowingAnalytics/DefaultServices (= 4.5.0)
-    - GrowingAnalytics/MobileDebugger (= 4.5.0)
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAnalytics/TrackerCore (4.5.0):
-    - GrowingUtils/TrackerCore (~> 1.2.3)
-  - GrowingAnalytics/WebCircle (4.5.0):
-    - GrowingAnalytics/AutotrackerCore (= 4.5.0)
-    - GrowingAnalytics/Hybrid (= 4.5.0)
-    - GrowingAnalytics/Screenshot (= 4.5.0)
-    - GrowingAnalytics/WebSocket (= 4.5.0)
-  - GrowingAnalytics/WebSocket (4.5.0):
-    - GrowingAnalytics/TrackerCore (= 4.5.0)
-  - GrowingAPM (1.0.1):
-    - GrowingAPM/Core (= 1.0.1)
-    - GrowingAPM/CrashMonitor (= 1.0.1)
-    - GrowingAPM/UIMonitor (= 1.0.1)
-  - GrowingAPM/Core (1.0.1):
+  - GrowingAnalytics/Screenshot (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/Tracker (4.6.0):
+    - GrowingAnalytics/DefaultServices (= 4.6.0)
+    - GrowingAnalytics/MobileDebugger (= 4.6.0)
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAnalytics/TrackerCore (4.6.0):
+    - GrowingUtils/TrackerCore (~> 1.2.4)
+  - GrowingAnalytics/WebCircle (4.6.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.6.0)
+    - GrowingAnalytics/Hybrid (= 4.6.0)
+    - GrowingAnalytics/Screenshot (= 4.6.0)
+    - GrowingAnalytics/WebSocket (= 4.6.0)
+  - GrowingAnalytics/WebSocket (4.6.0):
+    - GrowingAnalytics/TrackerCore (= 4.6.0)
+  - GrowingAPM (1.0.2):
+    - GrowingAPM/Core (= 1.0.2)
+    - GrowingAPM/CrashMonitor (= 1.0.2)
+    - GrowingAPM/UIMonitor (= 1.0.2)
+  - GrowingAPM/Core (1.0.2):
     - GrowingUtils/TrackerCore
-  - GrowingAPM/CrashMonitor (1.0.1):
+  - GrowingAPM/CrashMonitor (1.0.2):
     - GrowingAPM/Core
-  - GrowingAPM/UIMonitor (1.0.1):
+  - GrowingAPM/UIMonitor (1.0.2):
     - GrowingAPM/Core
-  - GrowingToolsKit (2.0.2):
-    - GrowingToolsKit/Default (= 2.0.2)
-  - GrowingToolsKit/APMCore (2.0.2):
+  - GrowingToolsKit (2.0.3):
+    - GrowingToolsKit/Default (= 2.0.3)
+  - GrowingToolsKit/APMCore (2.0.3):
     - GrowingAPM/Core
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Core (2.0.2)
-  - GrowingToolsKit/CrashMonitor (2.0.2):
+  - GrowingToolsKit/Core (2.0.3)
+  - GrowingToolsKit/CrashMonitor (2.0.3):
     - GrowingAPM/CrashMonitor
     - GrowingToolsKit/APMCore
-  - GrowingToolsKit/Default (2.0.2):
+  - GrowingToolsKit/Default (2.0.3):
     - GrowingToolsKit/Core
     - GrowingToolsKit/CrashMonitor
     - GrowingToolsKit/EventsList
@@ -90,27 +90,27 @@ PODS:
     - GrowingToolsKit/SDKInfo
     - GrowingToolsKit/Settings
     - GrowingToolsKit/XPathTrack
-  - GrowingToolsKit/EventsList (2.0.2):
+  - GrowingToolsKit/EventsList (2.0.3):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/LaunchTime (2.0.2):
+  - GrowingToolsKit/LaunchTime (2.0.3):
     - GrowingAPM/UIMonitor
     - GrowingToolsKit/APMCore
-  - GrowingToolsKit/NetFlow (2.0.2):
+  - GrowingToolsKit/NetFlow (2.0.3):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Realtime (2.0.2):
+  - GrowingToolsKit/Realtime (2.0.3):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/SDKInfo (2.0.2):
+  - GrowingToolsKit/SDKInfo (2.0.3):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/Settings (2.0.2):
+  - GrowingToolsKit/Settings (2.0.3):
     - GrowingToolsKit/Core
-  - GrowingToolsKit/XPathTrack (2.0.2):
+  - GrowingToolsKit/XPathTrack (2.0.3):
     - GrowingToolsKit/Core
-  - GrowingUtils/AutotrackerCore (1.2.3):
+  - GrowingUtils/AutotrackerCore (1.2.4):
     - GrowingUtils/TrackerCore
-  - GrowingUtils/TrackerCore (1.2.3)
-  - KIF (3.9.0):
-    - KIF/Core (= 3.9.0)
-  - KIF/Core (3.9.0)
+  - GrowingUtils/TrackerCore (1.2.4)
+  - KIF (3.11.1):
+    - KIF/Core (= 3.11.1)
+  - KIF/Core (3.11.1)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -124,12 +124,12 @@ PODS:
   - OHHTTPStubs/NSURLSession (9.1.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
-  - Protobuf (3.27.0)
+  - Protobuf (3.29.4)
   - SDCycleScrollView (1.82):
     - SDWebImage (>= 5.0.0)
-  - SDWebImage (5.19.2):
-    - SDWebImage/Core (= 5.19.2)
-  - SDWebImage/Core (5.19.2)
+  - SDWebImage (5.21.0):
+    - SDWebImage/Core (= 5.21.0)
+  - SDWebImage/Core (5.21.0)
 
 DEPENDENCIES:
   - GrowingAnalytics/ABTesting (from `../`)
@@ -160,15 +160,15 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: dd1b26e83f30a322f5c5c2dd7a4b8da65c0c0b3e
-  GrowingAPM: 3c4de0384935b654e6798b95606f47883a99418b
-  GrowingToolsKit: 53160d19690da0b78e04a9242abde7af86442922
-  GrowingUtils: 68aee2c96849bf9b674740503da30c2da468e79d
-  KIF: 2bd28f6c15e5b448d578668586acc8c3fe603f06
+  GrowingAnalytics: a2b80f2c88906e87c2852e5b3ae90ba520e76510
+  GrowingAPM: 4a3628e708cd1b2e4e1fc0925593781ed8acadd2
+  GrowingToolsKit: 2f17a8ab0c20d1967b7e50ef2365f04f2c3cfafd
+  GrowingUtils: 5d323e54798595015ff11e97fe981ae167dc270e
+  KIF: a48390ad8abb1ea373a3b7465213a02ade1724f6
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  Protobuf: 2c02b2e18bb9040d3bf3fd2cecaefb2a8b55265b
+  Protobuf: 2e6de032ba12b9efb390ae550d1a243a5b19ddfc
   SDCycleScrollView: a0d74c3384caa72bdfc81470bdbc8c14b3e1fbcf
-  SDWebImage: dfe95b2466a9823cf9f0c6d01217c06550d7b29a
+  SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
 
 PODFILE CHECKSUM: 8ef4d85701caba0f5df403432dc182d34412ab4a
 

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -44,7 +44,7 @@ GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和�
   end
 
   s.subspec 'TrackerCore' do |trackerCore|
-    trackerCore.dependency 'GrowingUtils/TrackerCore', '~> 1.2.3'
+    trackerCore.dependency 'GrowingUtils/TrackerCore', '~> 1.2.4'
     trackerCore.source_files = 'GrowingTrackerCore/**/*{.h,.m,.c,.cpp,.mm}'
     trackerCore.public_header_files = 'GrowingTrackerCore/Public/*.h'
     trackerCore.ios.resource_bundles = {'GrowingAnalytics' => ['Resources/iOS/GrowingAnalytics.bundle/PrivacyInfo.xcprivacy']}
@@ -58,7 +58,7 @@ GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和�
   s.subspec 'AutotrackerCore' do |autotrackerCore|
     autotrackerCore.ios.deployment_target = '10.0'
     autotrackerCore.tvos.deployment_target = '12.0'
-    autotrackerCore.dependency 'GrowingUtils/AutotrackerCore', '~> 1.2.3'
+    autotrackerCore.dependency 'GrowingUtils/AutotrackerCore', '~> 1.2.4'
     autotrackerCore.source_files = 'GrowingAutotrackerCore/**/*{.h,.m,.c,.cpp,.mm}'
     autotrackerCore.public_header_files = 'GrowingAutotrackerCore/Public/*.h'
     autotrackerCore.dependency 'GrowingAnalytics/TrackerCore', s.version.to_s

--- a/GrowingAutotrackerCore/Autotrack/UICollectionView+GrowingAutotracker.m
+++ b/GrowingAutotrackerCore/Autotrack/UICollectionView+GrowingAutotracker.m
@@ -25,8 +25,7 @@
 
 - (void)growing_setDelegate:(id<UICollectionViewDelegate>)delegate {
     SEL selector = @selector(collectionView:didSelectItemAtIndexPath:);
-    id<UICollectionViewDelegate> realDelegate = [GrowingULSwizzle realDelegate:delegate toSelector:selector];
-    Class class = realDelegate.class;
+    Class class = delegate.class;
     if ([GrowingULSwizzle realDelegateClass:class respondsToSelector:selector]) {
         static const void *key = &key;
         GrowingULSwizzleInstanceMethod(class,

--- a/GrowingAutotrackerCore/Autotrack/UITableView+GrowingAutotracker.m
+++ b/GrowingAutotrackerCore/Autotrack/UITableView+GrowingAutotracker.m
@@ -25,8 +25,7 @@
 
 - (void)growing_setDelegate:(id<UITableViewDelegate>)delegate {
     SEL selector = @selector(tableView:didSelectRowAtIndexPath:);
-    id<UITableViewDelegate> realDelegate = [GrowingULSwizzle realDelegate:delegate toSelector:selector];
-    Class class = realDelegate.class;
+    Class class = delegate.class;
     if ([GrowingULSwizzle realDelegateClass:class respondsToSelector:selector]) {
         static const void *key = &key;
         GrowingULSwizzleInstanceMethod(class,

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/growingio/growingio-sdk-ios-utilities.git",
-            "1.2.3" ..< "1.3.0"
+            "1.2.4" ..< "1.3.0"
         ),
         .package(
             url: "https://github.com/growingio/growingio-sdk-ios-performance-ext.git",


### PR DESCRIPTION
+[GrowingULSwizzle realDelegate:toSelector:] 已于 GrowingUtils 1.2.4 版本废弃，具体见：
https://github.com/growingio/growingio-sdk-ios-utilities/pull/5

此 PR 移除该接口调用，并修复 CI 报错