### PR TITLE
feat: add setPageTitle api in autotracker

### DIFF
--- a/GrowingAutotracker/GrowingAutotracker.h
+++ b/GrowingAutotracker/GrowingAutotracker.h
@@ -163,7 +163,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param title 页面标题
 /// @param controller 被追踪页面
 - (void)setPageTitle:(nullable NSString *)title
-             forPage:(UIViewController *)controller NS_EXTENSION_UNAVAILABLE("SetPageTitle is not supported for iOS extensions.");
+             forPage:(UIViewController *)controller
+    NS_EXTENSION_UNAVAILABLE("SetPageTitle is not supported for iOS extensions.");
 
 ///-------------------------------
 #pragma mark Unavailable

--- a/GrowingAutotracker/GrowingAutotracker.h
+++ b/GrowingAutotracker/GrowingAutotracker.h
@@ -159,6 +159,12 @@ NS_ASSUME_NONNULL_BEGIN
            attributes:(NSDictionary<NSString *, id> *)attributes
     NS_EXTENSION_UNAVAILABLE("AutotrackPage is not supported for iOS extensions.");
 
+/// 手动标识页面标题
+/// @param title 页面标题
+/// @param controller 被追踪页面
+- (void)setPageTitle:(nullable NSString *)title
+             forPage:(UIViewController *)controller NS_EXTENSION_UNAVAILABLE("SetPageTitle is not supported for iOS extensions.");
+
 ///-------------------------------
 #pragma mark Unavailable
 ///-------------------------------

--- a/GrowingAutotrackerCore/Autotrack/UIViewController+GrowingAutotracker.h
+++ b/GrowingAutotrackerCore/Autotrack/UIViewController+GrowingAutotracker.h
@@ -27,9 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) GrowingPage *growingPageObject;
 @property (nonatomic, copy) NSString *growingPageAlias;
+@property (nonatomic, copy, nullable) NSString *growingPageTitle;
 @property (nonatomic, copy) NSDictionary<NSString *, NSString *> *growingPageAttributes;
-
-- (nullable NSString *)growingPageTitle;
 
 @end
 

--- a/GrowingAutotrackerCore/Autotrack/UIViewController+GrowingAutotracker.m
+++ b/GrowingAutotrackerCore/Autotrack/UIViewController+GrowingAutotracker.m
@@ -21,20 +21,18 @@
 #import "GrowingAutotrackerCore/Autotrack/GrowingPropertyDefine.h"
 #import "GrowingAutotrackerCore/Page/GrowingPage.h"
 
+static char kGrowingPageTitleKey;
 static char kGrowingPageObjectKey;
 static char kGrowingPageAttributesKey;
 
 @implementation UIViewController (GrowingAutotracker)
 
+- (void)setGrowingPageTitle:(nullable NSString *)title {
+    objc_setAssociatedObject(self, &kGrowingPageTitleKey, title, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
 - (nullable NSString *)growingPageTitle {
-    NSString *title = self.title;
-    if (!title.length) {
-        title = self.navigationItem.title;
-    }
-    if (!title.length) {
-        title = self.tabBarItem.title;
-    }
-    return title;
+    return [objc_getAssociatedObject(self, &kGrowingPageTitleKey) copy];
 }
 
 - (void)setGrowingPageObject:(GrowingPage *)page {

--- a/GrowingAutotrackerCore/GrowingRealAutotracker.m
+++ b/GrowingAutotrackerCore/GrowingRealAutotracker.m
@@ -104,14 +104,13 @@ GrowingPropertyDefine(UITextView, NSString *, growingHookOldText, setGrowingHook
                    }];
 }
 
-- (void)setPageTitle:(nullable NSString *)title
-             forPage:(UIViewController *)controller {
+- (void)setPageTitle:(nullable NSString *)title forPage:(UIViewController *)controller {
     [GrowingDispatchManager trackApiSel:_cmd
                    dispatchInMainThread:^{
-        if (title && ![title isKindOfClass:[NSString class]]) {
-            return;
-        }
-        controller.growingPageTitle = title;
+                       if (title && ![title isKindOfClass:[NSString class]]) {
+                           return;
+                       }
+                       controller.growingPageTitle = title;
                    }];
 }
 

--- a/GrowingAutotrackerCore/GrowingRealAutotracker.m
+++ b/GrowingAutotrackerCore/GrowingRealAutotracker.m
@@ -104,6 +104,17 @@ GrowingPropertyDefine(UITextView, NSString *, growingHookOldText, setGrowingHook
                    }];
 }
 
+- (void)setPageTitle:(nullable NSString *)title
+             forPage:(UIViewController *)controller {
+    [GrowingDispatchManager trackApiSel:_cmd
+                   dispatchInMainThread:^{
+        if (title && ![title isKindOfClass:[NSString class]]) {
+            return;
+        }
+        controller.growingPageTitle = title;
+                   }];
+}
+
 - (void)addAutoTrackSwizzles {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/GrowingAutotrackerCore/Page/GrowingPage.m
+++ b/GrowingAutotrackerCore/Page/GrowingPage.m
@@ -82,7 +82,7 @@
     if (self.carrier.growingPageTitle) {
         return self.carrier.growingPageTitle;
     }
-    
+
     NSString *title = self.carrier.title;
     if (!title.length) {
         title = self.carrier.navigationItem.title;

--- a/GrowingAutotrackerCore/Page/GrowingPage.m
+++ b/GrowingAutotrackerCore/Page/GrowingPage.m
@@ -79,7 +79,18 @@
 }
 
 - (NSString *)title {
-    return self.carrier.growingPageTitle;
+    if (self.carrier.growingPageTitle) {
+        return self.carrier.growingPageTitle;
+    }
+    
+    NSString *title = self.carrier.title;
+    if (!title.length) {
+        title = self.carrier.navigationItem.title;
+    }
+    if (!title.length) {
+        title = self.carrier.tabBarItem.title;
+    }
+    return title;
 }
 
 - (NSDictionary<NSString *, NSString *> *)attributes {


### PR DESCRIPTION
* 添加手动标识页面标题接口，请在 ViewDidAppear 生命周期之前调用：
```swift
[[GrowingAutotracker sharedInstance] setPageTitle:@"custom_title" forPage:self];
```
* 设置 nil 时，使用原标题