### PR TITLE
feat: uniapp track page event support #338

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -24,7 +24,7 @@ jobs:
         os: [macos-15]
         include:
           - os: macos-15
-            xcode: Xcode_16.2
+            xcode: Xcode_16.4
           - target: iOS
             platform: iOS Simulator,name=iPhone 16 Pro Max
           - target: macOS
@@ -47,7 +47,7 @@ jobs:
             target: watchOS
           - target: visionOS
             os: macos-15
-            xcode: Xcode_16.2
+            xcode: Xcode_16.4
             platform: visionOS Simulator,name=Apple Vision Pro
             scheme: GrowingTracker
     runs-on: ${{ matrix.os }}

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -212,6 +212,12 @@ GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和�
     flutter.dependency 'GrowingAnalytics/TrackerCore', s.version.to_s
   end
 
+  s.subspec 'UniApp' do |uniapp|
+    uniapp.source_files = 'Modules/UniApp/**/*{.h,.m,.c,.cpp,.mm}'
+    uniapp.public_header_files = 'Modules/UniApp/Public/*.h'
+    uniapp.dependency 'GrowingAnalytics/TrackerCore', s.version.to_s
+  end
+
   s.subspec 'DISABLE_IDFA' do |config|
     config.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'GROWING_ANALYSIS_DISABLE_IDFA=1'}
     config.dependency 'GrowingAnalytics/TrackerCore', s.version.to_s

--- a/GrowingTrackerCore/Public/GrowingBaseEvent.h
+++ b/GrowingTrackerCore/Public/GrowingBaseEvent.h
@@ -34,7 +34,8 @@ typedef NS_OPTIONS(NSUInteger, GrowingEventSendPolicy) {
 typedef NS_ENUM(NSUInteger, GrowingEventScene) {
     GrowingEventSceneNative = 0,
     GrowingEventSceneHybrid,
-    GrowingEventSceneFlutter
+    GrowingEventSceneFlutter,
+    GrowingEventSceneUniApp
 };
 
 @interface GrowingBaseEvent : NSObject

--- a/Modules/UniApp/GrowingUniAppPlugin.m
+++ b/Modules/UniApp/GrowingUniAppPlugin.m
@@ -1,0 +1,76 @@
+//
+// GrowingUniAppPlugin.h
+// GrowingAnalytics
+//
+//  Created by YoloMao on 2024/12/2.
+//  Copyright (C) 2024 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import "Modules/UniApp/Public/GrowingUniAppPlugin.h"
+#import "GrowingTrackerCore/Event/Autotrack/GrowingPageEvent.h"
+#import "GrowingTrackerCore/Event/GrowingEventManager.h"
+#import "GrowingTrackerCore/Manager/GrowingSession.h"
+#import "GrowingTrackerCore/Public/GrowingAttributesBuilder.h"
+#import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
+
+GrowingMod(GrowingUniAppPlugin)
+
+@interface GrowingUniAppPlugin ()
+
+@end
+
+@implementation GrowingUniAppPlugin
+
+#pragma mark - GrowingModuleProtocol
+
+- (void)growingModInit:(GrowingContext *)context {
+}
+
++ (BOOL)singleton {
+    return YES;
+}
+
++ (instancetype)sharedInstance {
+    static id plugin = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        plugin = [[GrowingUniAppPlugin alloc] init];
+    });
+    return plugin;
+}
+
+#pragma mark - Autotrack Event
+
+- (void)trackPageEvent:(NSString *)pageName attributes:(NSDictionary<NSString *, NSString *> *_Nullable)attributes {
+    if (!pageName || ![pageName isKindOfClass:[NSString class]] || pageName.length == 0) {
+        return;
+    }
+    GrowingPageBuilder *builder = GrowingPageEvent.builder.setPath(pageName);
+    if (attributes) {
+        builder = builder.setAttributes(attributes);
+    }
+    [self trackAutotrackEventWithBuilder:builder];
+}
+
+- (void)trackAutotrackEventWithBuilder:(GrowingBaseBuilder *)builder {
+    [GrowingDispatchManager dispatchInGrowingThread:^{
+        if ([GrowingSession currentSession].state != GrowingSessionStateActive) {
+            return;
+        }
+        GrowingBaseBuilder *b = builder.setScene(GrowingEventSceneUniApp);
+        [[GrowingEventManager sharedInstance] postEventBuilder:b];
+    }];
+}
+
+@end

--- a/Modules/UniApp/Public/GrowingUniAppPlugin.h
+++ b/Modules/UniApp/Public/GrowingUniAppPlugin.h
@@ -1,0 +1,33 @@
+//
+// GrowingUniAppPlugin.h
+// GrowingAnalytics
+//
+//  Created by YoloMao on 2024/12/2.
+//  Copyright (C) 2024 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "GrowingModuleProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GrowingUniAppPlugin : NSObject <GrowingModuleProtocol>
+
++ (instancetype)sharedInstance;
+
+- (void)trackPageEvent:(NSString *)pageName attributes:(NSDictionary<NSString *, NSString *> *_Nullable)attributes;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
添加 uni-app 模块调用接口，用于 uts 插件集成，见：https://github.com/growingio/growing-sdk-uniapp/tree/op