### PR TITLE
fix: CTTelephonyNetworkInfo block main thread

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,66 +1,66 @@
 PODS:
-  - GrowingAnalytics/ABTesting (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/Ads (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/APM (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
+  - GrowingAnalytics/ABTesting (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/Ads (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/APM (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
     - GrowingAPM/Core (~> 1.0.1)
-  - GrowingAnalytics/Autotracker (4.9.1):
-    - GrowingAnalytics/AutotrackerCore (= 4.9.1)
-    - GrowingAnalytics/DefaultServices (= 4.9.1)
-    - GrowingAnalytics/Hybrid (= 4.9.1)
-    - GrowingAnalytics/MobileDebugger (= 4.9.1)
-    - GrowingAnalytics/WebCircle (= 4.9.1)
-  - GrowingAnalytics/AutotrackerCore (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
+  - GrowingAnalytics/Autotracker (4.10.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.10.0)
+    - GrowingAnalytics/DefaultServices (= 4.10.0)
+    - GrowingAnalytics/Hybrid (= 4.10.0)
+    - GrowingAnalytics/MobileDebugger (= 4.10.0)
+    - GrowingAnalytics/WebCircle (= 4.10.0)
+  - GrowingAnalytics/AutotrackerCore (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
     - GrowingUtils/AutotrackerCore (~> 1.2.4)
-  - GrowingAnalytics/Compression (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/Database (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/DefaultServices (4.9.1):
-    - GrowingAnalytics/Compression (= 4.9.1)
-    - GrowingAnalytics/Encryption (= 4.9.1)
-    - GrowingAnalytics/JSON (= 4.9.1)
-    - GrowingAnalytics/Network (= 4.9.1)
-    - GrowingAnalytics/Protobuf (= 4.9.1)
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/Encryption (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/Hybrid (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/ImpressionTrack (4.9.1):
-    - GrowingAnalytics/AutotrackerCore (= 4.9.1)
-  - GrowingAnalytics/JSON (4.9.1):
-    - GrowingAnalytics/Database (= 4.9.1)
-  - GrowingAnalytics/MobileDebugger (4.9.1):
-    - GrowingAnalytics/Screenshot (= 4.9.1)
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-    - GrowingAnalytics/WebSocket (= 4.9.1)
-  - GrowingAnalytics/Network (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/Protobuf (4.9.1):
-    - GrowingAnalytics/Database (= 4.9.1)
-    - GrowingAnalytics/Protobuf/Proto (= 4.9.1)
-  - GrowingAnalytics/Protobuf/Proto (4.9.1):
-    - GrowingAnalytics/Database (= 4.9.1)
+  - GrowingAnalytics/Compression (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/Database (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/DefaultServices (4.10.0):
+    - GrowingAnalytics/Compression (= 4.10.0)
+    - GrowingAnalytics/Encryption (= 4.10.0)
+    - GrowingAnalytics/JSON (= 4.10.0)
+    - GrowingAnalytics/Network (= 4.10.0)
+    - GrowingAnalytics/Protobuf (= 4.10.0)
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/Encryption (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/Hybrid (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/ImpressionTrack (4.10.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.10.0)
+  - GrowingAnalytics/JSON (4.10.0):
+    - GrowingAnalytics/Database (= 4.10.0)
+  - GrowingAnalytics/MobileDebugger (4.10.0):
+    - GrowingAnalytics/Screenshot (= 4.10.0)
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+    - GrowingAnalytics/WebSocket (= 4.10.0)
+  - GrowingAnalytics/Network (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/Protobuf (4.10.0):
+    - GrowingAnalytics/Database (= 4.10.0)
+    - GrowingAnalytics/Protobuf/Proto (= 4.10.0)
+  - GrowingAnalytics/Protobuf/Proto (4.10.0):
+    - GrowingAnalytics/Database (= 4.10.0)
     - Protobuf (~> 3.27)
-  - GrowingAnalytics/Screenshot (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/Tracker (4.9.1):
-    - GrowingAnalytics/DefaultServices (= 4.9.1)
-    - GrowingAnalytics/MobileDebugger (= 4.9.1)
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
-  - GrowingAnalytics/TrackerCore (4.9.1):
+  - GrowingAnalytics/Screenshot (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/Tracker (4.10.0):
+    - GrowingAnalytics/DefaultServices (= 4.10.0)
+    - GrowingAnalytics/MobileDebugger (= 4.10.0)
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
+  - GrowingAnalytics/TrackerCore (4.10.0):
     - GrowingUtils/TrackerCore (~> 1.2.4)
-  - GrowingAnalytics/WebCircle (4.9.1):
-    - GrowingAnalytics/AutotrackerCore (= 4.9.1)
-    - GrowingAnalytics/Hybrid (= 4.9.1)
-    - GrowingAnalytics/Screenshot (= 4.9.1)
-    - GrowingAnalytics/WebSocket (= 4.9.1)
-  - GrowingAnalytics/WebSocket (4.9.1):
-    - GrowingAnalytics/TrackerCore (= 4.9.1)
+  - GrowingAnalytics/WebCircle (4.10.0):
+    - GrowingAnalytics/AutotrackerCore (= 4.10.0)
+    - GrowingAnalytics/Hybrid (= 4.10.0)
+    - GrowingAnalytics/Screenshot (= 4.10.0)
+    - GrowingAnalytics/WebSocket (= 4.10.0)
+  - GrowingAnalytics/WebSocket (4.10.0):
+    - GrowingAnalytics/TrackerCore (= 4.10.0)
   - GrowingAPM (1.0.2):
     - GrowingAPM/Core (= 1.0.2)
     - GrowingAPM/CrashMonitor (= 1.0.2)
@@ -152,7 +152,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: 1be48aac3f41ac95fcd34f6040fa8866f181c28d
+  GrowingAnalytics: e77ff4ce3bc8e2888792a79ff5e14f860a093f3d
   GrowingAPM: 4a3628e708cd1b2e4e1fc0925593781ed8acadd2
   GrowingToolsKit: 548d35d9b5964af3a73f80b30c6948dc10d247b4
   GrowingUtils: 5d323e54798595015ff11e97fe981ae167dc270e

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -270,7 +270,13 @@ const int GrowingTrackerVersionCode = 41000;
 }
 
 - (void)flushEvents {
-    [[GrowingEventManager sharedInstance] sendAllChannelEvents];
+    [GrowingDispatchManager dispatchInGrowingThread:^{
+        GrowingTrackConfiguration *trackConfiguration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
+        if (!trackConfiguration.dataCollectionEnabled) {
+            return;
+        }
+        [[GrowingEventManager sharedInstance] sendAllChannelEvents];
+    }];
 }
 
 @end

--- a/GrowingTrackerCore/Network/GrowingNetworkInterfaceManager.m
+++ b/GrowingTrackerCore/Network/GrowingNetworkInterfaceManager.m
@@ -20,8 +20,8 @@
 #import "GrowingTrackerCore/Network/GrowingNetworkInterfaceManager.h"
 #import "GrowingTargetConditionals.h"
 #import "GrowingTrackerCore/Network/GrowingNetworkPathMonitor.h"
-#import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
 #import "GrowingTrackerCore/Thirdparty/Reachability/GrowingReachability.h"
+#import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
 
 #if Growing_OS_PURE_IOS
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
@@ -92,10 +92,10 @@
                     }
                 }
             } else {
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 accessString = self.teleInfo.currentRadioAccessTechnology;
-    #pragma clang diagnostic pop
+#pragma clang diagnostic pop
             }
         }
 

--- a/GrowingTrackerCore/Network/GrowingNetworkInterfaceManager.m
+++ b/GrowingTrackerCore/Network/GrowingNetworkInterfaceManager.m
@@ -20,6 +20,7 @@
 #import "GrowingTrackerCore/Network/GrowingNetworkInterfaceManager.h"
 #import "GrowingTargetConditionals.h"
 #import "GrowingTrackerCore/Network/GrowingNetworkPathMonitor.h"
+#import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
 #import "GrowingTrackerCore/Thirdparty/Reachability/GrowingReachability.h"
 
 #if Growing_OS_PURE_IOS
@@ -55,7 +56,12 @@
         _monitorQueue = dispatch_queue_create("com.growingio.network.monitorQueue", DISPATCH_QUEUE_SERIAL);
 
 #if Growing_OS_PURE_IOS
-        _teleInfo = [[CTTelephonyNetworkInfo alloc] init];
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+            CTTelephonyNetworkInfo *info = [[CTTelephonyNetworkInfo alloc] init];
+            [GrowingDispatchManager dispatchInGrowingThread:^{
+                self.teleInfo = info;
+            }];
+        });
 #endif
         [self monitorInitialize];
     }
@@ -77,18 +83,20 @@
 #elif Growing_OS_PURE_IOS
         NSArray *typeStrings4G = @[CTRadioAccessTechnologyLTE];
         NSString *accessString = CTRadioAccessTechnologyLTE;  // default 4G
-        if (@available(iOS 12.0, *)) {
-            if ([self.teleInfo respondsToSelector:@selector(serviceCurrentRadioAccessTechnology)]) {
-                NSDictionary *radioDic = self.teleInfo.serviceCurrentRadioAccessTechnology;
-                if (radioDic.count) {
-                    accessString = radioDic[radioDic.allKeys.firstObject];
+        if (self.teleInfo) {
+            if (@available(iOS 12.0, *)) {
+                if ([self.teleInfo respondsToSelector:@selector(serviceCurrentRadioAccessTechnology)]) {
+                    NSDictionary *radioDic = self.teleInfo.serviceCurrentRadioAccessTechnology;
+                    if (radioDic.count) {
+                        accessString = radioDic[radioDic.allKeys.firstObject];
+                    }
                 }
+            } else {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                accessString = self.teleInfo.currentRadioAccessTechnology;
+    #pragma clang diagnostic pop
             }
-        } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            accessString = self.teleInfo.currentRadioAccessTechnology;
-#pragma clang diagnostic pop
         }
 
         if ([typeStrings4G containsObject:accessString]) {


### PR DESCRIPTION
* fix #357，可能 CTTelephonyNetworkInfo init 在某些系统版本中，极小概率会卡死主线程，此 PR 将切换到并发子线程中调用，且在 GrowingThread 赋值

> [官方文档](https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo)没有明确说必须在主线程或者子线程执行 init
>
> 看了下其他埋点 SDK 仓库：
> * [MixPanel](https://github.com/senselabs/mixpanel-iphone/blob/c0bef6dcca1dea0ac682023c1755b39940b9836e/Mixpanel/Mixpanel.m#L154) 在主线程执行
> * [Amplitude](https://github.com/Triaged/Amplitude-iOS/blob/efa761ba200191e5cc79b4c2f7059a2bf3fca388/Amplitude.m#L89) 在并发子线程执行
