### PR TITLE
feat: add GrowingModule_Flutter product to Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,7 @@ let package = Package(
         .Module.ads,
         .Module.apm,
         .Module.abTesting,
+        .Module.flutter,
     ],
     dependencies: [
         .package(
@@ -89,6 +90,7 @@ let package = Package(
         .Module.ads,
         .Module.apm,
         .Module.abTesting,
+        .Module.flutter,
 
         // MARK: - Services
 
@@ -114,6 +116,7 @@ extension Product {
         static let ads = library(name: .ads, targets: [.ads])
         static let apm = library(name: .apm, targets: [.apm])
         static let abTesting = library(name: .abTesting, targets: [.abTesting])
+        static let flutter = library(name: .flutter, targets: [.flutter])
     }
 }
 
@@ -263,6 +266,12 @@ extension Target {
                                       path: .Path.abTesting,
                                       publicHeadersPath: .Path.publicHeaders,
                                       cSettings: [.hspFor(.Path.abTesting)])
+
+        static let flutter = target(name: .flutter,
+                                    dependencies: [.Core.trackerCore],
+                                    path: .Path.flutter,
+                                    publicHeadersPath: ".",
+                                    cSettings: [.hspFor(.Path.flutter)])
     }
 
     enum Service {
@@ -400,6 +409,7 @@ extension String {
     static let ads = "GrowingModule_Ads"
     static let apm = "GrowingModule_APM"
     static let abTesting = "GrowingModule_ABTesting"
+    static let flutter = "GrowingModule_Flutter"
 
     // Services
     static let database = "GrowingService_Database"
@@ -439,6 +449,7 @@ extension String {
         static let apm = "Modules/APM"
         static let abTesting = "Modules/ABTesting"
         static let coreServices = "Modules/DefaultServices"
+        static let flutter = "Modules/Flutter"
 
         // Services
         static let database = "Services/Database"


### PR DESCRIPTION
## 变更内容

Package.swift 新增 `GrowingModule_Flutter` product + target，将 Flutter 模块（`Modules/Flutter`，即 CocoaPods `GrowingAnalytics/Flutter` subspec 的对应物）暴露为 SwiftPM 库产品：

- target 路径 `Modules/Flutter`，依赖 `GrowingTrackerCore`（与 podspec subspec 声明一致）
- `publicHeadersPath: "."`，使外部包可 `#import "GrowingFlutterPlugin.h"`（与 `GrowingAutotracker_Objc` 等 target 同一模式）
- header search path 沿用 `.hspFor` 惯例，模块内部对 `GrowingTrackerCore/...` 内部头文件的引用保持不变

## 背景

growingio-sdk-flutter 正在适配 Swift Package Manager（growingio/growingio-sdk-flutter#52），Flutter 插件的 Swift Package 需要依赖本模块，但此前 SPM 产品列表中缺失（仅 CocoaPods subspec 提供）。

已在 Flutter example 工程中以本地包依赖完整验证：SPM 模式构建、模拟器运行、事件上报均正常。

## 后续

合并后需发布 **4.12.0**，growingio/growingio-sdk-flutter#52 依赖该版本号（插件 Package.swift 将锁定 `"4.12.0" ..< "5.0.0"`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)