### PR TITLE
feat: add GrowingModule_Flutter product to Swift Package (3.x)

### DIFF
--- a/GrowingAutotrackerCore/GrowingRealAutotracker.m
+++ b/GrowingAutotrackerCore/GrowingRealAutotracker.m
@@ -142,11 +142,10 @@ GrowingPropertyDefine(UITextView, NSString *, growingHookOldText, setGrowingHook
                                         withMethod:@selector(growing_dismissAnimated:triggeringAction:)
                                              error:&alertError];
 
-        [UIAlertController
-            growingul_swizzleMethod:dismissActionSELFromIOS11
-                         withMethod:@selector(growing_dismissAnimated:
-                                                     triggeringAction:triggeredByPopoverDimmingView:dismissCompletion:)
-                              error:&alertError];
+        [UIAlertController growingul_swizzleMethod:dismissActionSELFromIOS11
+                                        withMethod:@selector(growing_dismissAnimated:triggeringAction:
+                                                             triggeredByPopoverDimmingView:dismissCompletion:)
+                                             error:&alertError];
 
         if (alertError) {
             GIOLogError(@"Failed to swizzle UIAlertController. Details: %@", alertError);

--- a/Modules/SwiftProtobuf/SwiftProtobuf.swift
+++ b/Modules/SwiftProtobuf/SwiftProtobuf.swift
@@ -43,8 +43,7 @@ public class SwiftProtobufWrapper: NSObject {
     public func toJsonObject() -> [String: AnyObject]? {
         do {
             let data = try unbox.jsonUTF8Data()
-            let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: AnyObject]
-            return json
+            return try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: AnyObject]
         } catch {
             return nil
         }
@@ -71,7 +70,7 @@ public class SwiftProtobufWrapper: NSObject {
 }
 
 public extension SwiftProtobufWrapper {
-    // For GrowingToolsKit NetFlow
+    /// For GrowingToolsKit NetFlow
     @objc(convertProtobufDataToJsonArray:)
     static func convertProtobufDataToJsonArray(from data: Data) -> [[String: AnyObject]]? {
         do {

--- a/Package.swift
+++ b/Package.swift
@@ -74,6 +74,10 @@ let package = Package(
             name: "GrowingModule_APM",
             targets: ["GrowingModule_APM"]
         ),
+        .library(
+            name: "GrowingModule_Flutter",
+            targets: ["GrowingModule_Flutter"]
+        ),
     ],
     dependencies: [
         .package(
@@ -386,6 +390,15 @@ let package = Package(
             ],
             path: "Modules/APM",
             publicHeadersPath: "Public",
+            cSettings: [
+                .headerSearchPath("../.."),
+            ]
+        ),
+        .target(
+            name: "GrowingModule_Flutter",
+            dependencies: ["GrowingTrackerCore"],
+            path: "Modules/Flutter",
+            publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath("../.."),
             ]


### PR DESCRIPTION
## 变更内容

Package.swift（3.x 线）新增 `GrowingModule_Flutter` product + target，将 Flutter 模块（`Modules/Flutter`，即 CocoaPods `GrowingAnalytics/Flutter` subspec 的对应物）暴露为 SwiftPM 库产品：

- target 路径 `Modules/Flutter`，依赖 `GrowingTrackerCore`（与 podspec subspec 声明一致）
- `publicHeadersPath: "."`，使外部包可 `#import "GrowingFlutterPlugin.h"`
- header search path 沿用本文件既有惯例（`../..`），模块内部对 `GrowingTrackerCore/...` 内部头文件的引用保持不变

与 master 线的 #362 为同一改动，分别应用于两条版本线。

## 背景

growingio-sdk-flutter 的 cdp/2.x 分支正在适配 Swift Package Manager，tracker/autotracker 两个插件的 Swift Package 需要依赖本模块，此前 3.x 的 SPM 产品列表中缺失（仅 CocoaPods subspec 提供）。

已在 Flutter example 工程中以本地包依赖完整验证：SPM 模式构建、模拟器运行、CDP 事件上报均正常。

## 后续

合并后需在 3.x 线发布新版本（3.9.2 或 3.10.0），growingio-sdk-flutter 的 cdp/2.x SPM 适配 PR 依赖该版本号（插件 Package.swift 将锁定 `"3.9.2" ..< "4.0.0"`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)