### PR TITLE
ci: add SPM build workflow (3.x)

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -1,0 +1,26 @@
+name: SPM
+
+on:
+  push:
+    branches: [ base/3.x ]
+  pull_request:
+    branches: [ base/3.x ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spm-build:
+    runs-on: macos-15
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app
+      - name: Build
+        run: |
+          set -euo pipefail
+          xcodebuild build -scheme GrowingAnalytics-Package \
+          -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+          | xcbeautify --renderer github-actions


### PR DESCRIPTION
## 变更内容

从 master 线 backport `spm.yml` 到 3.x 线，裁剪为单 job：

- 触发条件：push / pull_request 针对 `base/3.x`（master 版的 `branches: [ master ]` 在本线永远不会触发，此为必改点）
- 单 iOS Simulator job，构建 `GrowingAnalytics-Package` umbrella scheme——编译包内**全部** SwiftPM target，后续新增 product（如 #363 的 `GrowingModule_Flutter`）自动纳入，无需再改本文件
- Xcode 26.0.1 + iPhone 17 Pro Max，与本线现有 Testing workflow（`ci_without_report.yml`）对齐
- 不引入 master 版的多平台矩阵：3.x `Package.swift` 仅声明 iOS/macCatalyst/macOS，且本线为维护线，iOS 单 job 性价比最高

## 背景

3.x 线此前没有任何 SPM 构建 CI，`Package.swift` 及各 target 从未被 CI 验证。随着 #363 将 `GrowingModule_Flutter` 暴露为 SPM product（growingio-sdk-flutter 的 cdp/2.x SPM 适配依赖它），需要保证 SwiftPM 编译路径不被后续改动静默破坏。

## 与 #363 的关系

合并顺序无依赖。两者都合并后，`Modules/Flutter` 才真正进入 CI 编译路径。

## 验证

- 本地在 base/3.x 代码上执行 workflow 核心命令 `xcodebuild build -scheme GrowingAnalytics-Package -destination 'generic/platform=iOS Simulator'` → BUILD SUCCEEDED（仅既有 deprecation warnings）
- YAML 语法校验通过；`xcbeautify` 在 macos-15 runner 预装（master 线 `spm.yml` 同样裸用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)