### PR TITLE
feat: release 3.9.2

### DIFF
--- a/Example/GrowingAnalyticsTests/ModulesTests/AdvertTests/AdvertTest.m
+++ b/Example/GrowingAnalyticsTests/ModulesTests/AdvertTests/AdvertTest.m
@@ -30,11 +30,23 @@
 
 #import "MockEventQueue.h"
 
+// 注意：test01 依赖 test00 先执行完毕（XCTest 默认按类内方法名字母序执行，
+// 当前 testplan 未开启 test randomization）；若日后开启随机化，需重审这两个用例的隔离性
 @interface AdvertTest : XCTestCase
 
 @end
 
 @implementation AdvertTest
+
+// activate 事件生成链路含异步步骤（如 WKWebView UA 获取），耗时不定，
+// 不能用固定延时后断言（CI 慢机器上曾导致 flaky），改用谓词轮询等待
+- (void)waitForActivateEventWithTimeout:(NSTimeInterval)timeout {
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id _Nullable object, NSDictionary *_Nullable bindings) {
+        return [MockEventQueue.sharedQueue eventCountFor:GrowingEventTypeActivate] >= 1;
+    }];
+    [self expectationForPredicate:predicate evaluatedWithObject:MockEventQueue.sharedQueue handler:nil];
+    [self waitForExpectationsWithTimeout:timeout handler:nil];
+}
 
 - (void)setUp {
     [MockEventQueue.sharedQueue cleanQueue];
@@ -45,20 +57,20 @@
 }
 
 - (void)test00SendActivateEvent {
+    // 重置激活标记（GrowingAdUtils 持久化于文件存储）：
+    // 避免隐式依赖"干净模拟器"，否则本地复跑或复用模拟器的环境下 activate 事件不会再次发送
+    [GrowingAdUtils setActivateWrote:NO];
+    [GrowingAdUtils setActivateSent:NO];
+
     GrowingAutotrackConfiguration *configuration = [GrowingAutotrackConfiguration configurationWithProjectId:@"test"];
     configuration.dataSourceId = @"test";
     configuration.urlScheme = @"growing.530c8231345c492d";
     [GrowingAutotracker startWithConfiguration:configuration launchOptions:nil];
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SendActivateEvent Test failed : timeout"];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        // 给 webView 一点时间
-        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeActivate];
-        XCTAssertEqual(events.count, 1);
-
-        [expectation fulfill];
-    });
-    [self waitForExpectationsWithTimeout:10.0f handler:nil];
+    [self waitForActivateEventWithTimeout:30.0f];
+    // 断言保持 == 1（而非 >= 1）：用于检测 activate 事件重复发送的回归
+    NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeActivate];
+    XCTAssertEqual(events.count, 1);
 }
 
 - (void)test01SetDataCollectionEnabled {
@@ -69,15 +81,10 @@
     [[GrowingAutotracker sharedInstance] setDataCollectionEnabled:NO];
     [[GrowingAutotracker sharedInstance] setDataCollectionEnabled:YES];
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SetDataCollectionEnabled Test failed : timeout"];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        // 给 webView 一点时间
-        NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeActivate];
-        XCTAssertEqual(events.count, 1);
-
-        [expectation fulfill];
-    });
-    [self waitForExpectationsWithTimeout:10.0f handler:nil];
+    [self waitForActivateEventWithTimeout:30.0f];
+    // 断言保持 == 1（而非 >= 1）：用于检测 activate 事件重复发送的回归
+    NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeActivate];
+    XCTAssertEqual(events.count, 1);
 }
 
 @end

--- a/Example/GrowingAnalyticsTests/ModulesTests/AdvertTests/AdvertTest.m
+++ b/Example/GrowingAnalyticsTests/ModulesTests/AdvertTests/AdvertTest.m
@@ -17,11 +17,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
 #import <XCTest/XCTest.h>
 
-#import "GrowingAutotracker.h"
 #import "GrowingAdvertising.h"
+#import "GrowingAutotracker.h"
 #import "GrowingTrackerCore/Manager/GrowingConfigurationManager.h"
 #import "GrowingTrackerCore/Thread/GrowingDispatchManager.h"
 
@@ -41,9 +40,10 @@
 // activate 事件生成链路含异步步骤（如 WKWebView UA 获取），耗时不定，
 // 不能用固定延时后断言（CI 慢机器上曾导致 flaky），改用谓词轮询等待
 - (void)waitForActivateEventWithTimeout:(NSTimeInterval)timeout {
-    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id _Nullable object, NSDictionary *_Nullable bindings) {
-        return [MockEventQueue.sharedQueue eventCountFor:GrowingEventTypeActivate] >= 1;
-    }];
+    NSPredicate *predicate =
+        [NSPredicate predicateWithBlock:^BOOL(id _Nullable object, NSDictionary *_Nullable bindings) {
+            return [MockEventQueue.sharedQueue eventCountFor:GrowingEventTypeActivate] >= 1;
+        }];
     [self expectationForPredicate:predicate evaluatedWithObject:MockEventQueue.sharedQueue handler:nil];
     [self waitForExpectationsWithTimeout:timeout handler:nil];
 }
@@ -53,7 +53,6 @@
 }
 
 - (void)tearDown {
-
 }
 
 - (void)test00SendActivateEvent {
@@ -66,7 +65,7 @@
     configuration.dataSourceId = @"test";
     configuration.urlScheme = @"growing.530c8231345c492d";
     [GrowingAutotracker startWithConfiguration:configuration launchOptions:nil];
-    
+
     [self waitForActivateEventWithTimeout:30.0f];
     // 断言保持 == 1（而非 >= 1）：用于检测 activate 事件重复发送的回归
     NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeActivate];
@@ -77,10 +76,10 @@
     // 恢复为未发送激活事件
     [GrowingAdUtils setActivateWrote:NO];
     [GrowingAdUtils setActivateSent:NO];
-    
+
     [[GrowingAutotracker sharedInstance] setDataCollectionEnabled:NO];
     [[GrowingAutotracker sharedInstance] setDataCollectionEnabled:YES];
-    
+
     [self waitForActivateEventWithTimeout:30.0f];
     // 断言保持 == 1（而非 >= 1）：用于检测 activate 事件重复发送的回归
     NSArray<GrowingBaseEvent *> *events = [MockEventQueue.sharedQueue eventsFor:GrowingEventTypeActivate];

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,71 +1,71 @@
 PODS:
-  - GrowingAnalytics-cdp/Autotracker (3.9.1):
-    - GrowingAnalytics/AutotrackerCore (= 3.9.1)
-    - GrowingAnalytics/DefaultServices (= 3.9.1)
-    - GrowingAnalytics/Hybrid (= 3.9.1)
-    - GrowingAnalytics/MobileDebugger (= 3.9.1)
-    - GrowingAnalytics/WebCircle (= 3.9.1)
-  - GrowingAnalytics-cdp/Tracker (3.9.1):
-    - GrowingAnalytics/DefaultServices (= 3.9.1)
-    - GrowingAnalytics/MobileDebugger (= 3.9.1)
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/Advert (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/APM (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
+  - GrowingAnalytics-cdp/Autotracker (3.9.2):
+    - GrowingAnalytics/AutotrackerCore (= 3.9.2)
+    - GrowingAnalytics/DefaultServices (= 3.9.2)
+    - GrowingAnalytics/Hybrid (= 3.9.2)
+    - GrowingAnalytics/MobileDebugger (= 3.9.2)
+    - GrowingAnalytics/WebCircle (= 3.9.2)
+  - GrowingAnalytics-cdp/Tracker (3.9.2):
+    - GrowingAnalytics/DefaultServices (= 3.9.2)
+    - GrowingAnalytics/MobileDebugger (= 3.9.2)
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/Advert (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/APM (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
     - GrowingAPM/Core
-  - GrowingAnalytics/Autotracker (3.9.1):
-    - GrowingAnalytics/AutotrackerCore (= 3.9.1)
-    - GrowingAnalytics/DefaultServices (= 3.9.1)
-    - GrowingAnalytics/Hybrid (= 3.9.1)
-    - GrowingAnalytics/MobileDebugger (= 3.9.1)
-    - GrowingAnalytics/WebCircle (= 3.9.1)
-  - GrowingAnalytics/AutotrackerCore (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
+  - GrowingAnalytics/Autotracker (3.9.2):
+    - GrowingAnalytics/AutotrackerCore (= 3.9.2)
+    - GrowingAnalytics/DefaultServices (= 3.9.2)
+    - GrowingAnalytics/Hybrid (= 3.9.2)
+    - GrowingAnalytics/MobileDebugger (= 3.9.2)
+    - GrowingAnalytics/WebCircle (= 3.9.2)
+  - GrowingAnalytics/AutotrackerCore (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
     - GrowingUtils/AutotrackerCore (~> 1.2.4)
-  - GrowingAnalytics/Compression (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/Database (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/DefaultServices (3.9.1):
-    - GrowingAnalytics/Compression (= 3.9.1)
-    - GrowingAnalytics/Database (= 3.9.1)
-    - GrowingAnalytics/Encryption (= 3.9.1)
-    - GrowingAnalytics/Network (= 3.9.1)
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/Encryption (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/Hybrid (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/MobileDebugger (3.9.1):
-    - GrowingAnalytics/Screenshot (= 3.9.1)
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-    - GrowingAnalytics/WebSocket (= 3.9.1)
-  - GrowingAnalytics/Network (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/Protobuf (3.9.1):
-    - GrowingAnalytics/Database (= 3.9.1)
-    - GrowingAnalytics/Protobuf/Proto (= 3.9.1)
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/Protobuf/Proto (3.9.1):
-    - GrowingAnalytics/Database (= 3.9.1)
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
+  - GrowingAnalytics/Compression (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/Database (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/DefaultServices (3.9.2):
+    - GrowingAnalytics/Compression (= 3.9.2)
+    - GrowingAnalytics/Database (= 3.9.2)
+    - GrowingAnalytics/Encryption (= 3.9.2)
+    - GrowingAnalytics/Network (= 3.9.2)
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/Encryption (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/Hybrid (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/MobileDebugger (3.9.2):
+    - GrowingAnalytics/Screenshot (= 3.9.2)
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+    - GrowingAnalytics/WebSocket (= 3.9.2)
+  - GrowingAnalytics/Network (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/Protobuf (3.9.2):
+    - GrowingAnalytics/Database (= 3.9.2)
+    - GrowingAnalytics/Protobuf/Proto (= 3.9.2)
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/Protobuf/Proto (3.9.2):
+    - GrowingAnalytics/Database (= 3.9.2)
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
     - Protobuf
-  - GrowingAnalytics/Screenshot (3.9.1):
+  - GrowingAnalytics/Screenshot (3.9.2):
     - GrowingAnalytics/TrackerCore
-  - GrowingAnalytics/Tracker (3.9.1):
-    - GrowingAnalytics/DefaultServices (= 3.9.1)
-    - GrowingAnalytics/MobileDebugger (= 3.9.1)
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
-  - GrowingAnalytics/TrackerCore (3.9.1):
+  - GrowingAnalytics/Tracker (3.9.2):
+    - GrowingAnalytics/DefaultServices (= 3.9.2)
+    - GrowingAnalytics/MobileDebugger (= 3.9.2)
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
+  - GrowingAnalytics/TrackerCore (3.9.2):
     - GrowingUtils/TrackerCore (~> 1.2.4)
-  - GrowingAnalytics/WebCircle (3.9.1):
-    - GrowingAnalytics/AutotrackerCore (= 3.9.1)
-    - GrowingAnalytics/Hybrid (= 3.9.1)
-    - GrowingAnalytics/Screenshot (= 3.9.1)
-    - GrowingAnalytics/WebSocket (= 3.9.1)
-  - GrowingAnalytics/WebSocket (3.9.1):
-    - GrowingAnalytics/TrackerCore (= 3.9.1)
+  - GrowingAnalytics/WebCircle (3.9.2):
+    - GrowingAnalytics/AutotrackerCore (= 3.9.2)
+    - GrowingAnalytics/Hybrid (= 3.9.2)
+    - GrowingAnalytics/Screenshot (= 3.9.2)
+    - GrowingAnalytics/WebSocket (= 3.9.2)
+  - GrowingAnalytics/WebSocket (3.9.2):
+    - GrowingAnalytics/TrackerCore (= 3.9.2)
   - GrowingAPM (1.0.2):
     - GrowingAPM/Core (= 1.0.2)
     - GrowingAPM/CrashMonitor (= 1.0.2)
@@ -153,8 +153,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GrowingAnalytics: ab58b1e52000a3d37298783c34d32f4560ca4e2b
-  GrowingAnalytics-cdp: f72f50e72d79b9d9366b0a4e729097b3f1a15e14
+  GrowingAnalytics: 595d59e1cc733176a55a6fcc55682e98cc3861ce
+  GrowingAnalytics-cdp: 2689d8f6017f73c2ca6a10c430a41a0cc8abbcb0
   GrowingAPM: 4a3628e708cd1b2e4e1fc0925593781ed8acadd2
   GrowingToolsKit: 548d35d9b5964af3a73f80b30c6948dc10d247b4
   GrowingUtils: 5d323e54798595015ff11e97fe981ae167dc270e

--- a/GrowingAnalytics-cdp.podspec
+++ b/GrowingAnalytics-cdp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics-cdp'
-  s.version          = '3.9.1'
+  s.version          = '3.9.2'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics-cdp基于GrowingAnalytics，同样具备自动采集基本的用户行为事件，比如访问和行为数据等。

--- a/GrowingAnalytics.podspec
+++ b/GrowingAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics'
-  s.version          = '3.9.1'
+  s.version          = '3.9.2'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/GrowingTrackerCore/GrowingRealTracker.m
+++ b/GrowingTrackerCore/GrowingRealTracker.m
@@ -38,8 +38,8 @@
 #import "GrowingTrackerCore/Utils/GrowingDeviceInfo.h"
 #import "GrowingULAppLifecycle.h"
 
-NSString *const GrowingTrackerVersionName = @"3.9.1";
-const int GrowingTrackerVersionCode = 30901;
+NSString *const GrowingTrackerVersionName = @"3.9.2";
+const int GrowingTrackerVersionCode = 30902;
 
 @interface GrowingRealTracker ()
 


### PR DESCRIPTION
## 变更内容

### 发版 3.9.2

`sh scripts/update_version.sh 3.9.2`：

- `GrowingTrackerCore/GrowingRealTracker.m`：`GrowingTrackerVersionName` → `3.9.2`，`GrowingTrackerVersionCode` → `30902`
- `GrowingAnalytics.podspec` / `GrowingAnalytics-cdp.podspec`：`s.version` → `3.9.2`
- `Example/Podfile.lock`：`pod install` 刷新（仅版本号与两个 podspec checksum，无依赖变更）

### 修复 AdvertTest flaky（近 5 次 Testing 运行挂 3 次）

两个根因，一并修复：

1. **固定延时不可靠**：原实现 `dispatch_after` 固定 5s 后断言 `events.count == 1`。activate 事件生成链路含异步步骤（WKWebView UA 获取等）耗时不定——本地实测 test00 事件到达耗时 7.2s / 8.5s，超过 5s 即挂（`0 != 1`）；test00 的事件迟到落进 test01 队列则 `2 != 1`（与 CI 失败形态完全吻合）。改用 XCTest 原生 `expectationForPredicate:` 轮询（约 1s 间隔），事件到达即返回，超时上限放宽至 30s。
2. **隐式依赖干净模拟器**：`GrowingAdUtils` 将 `ActivateSent/ActivateWrote` 标记持久化到文件存储，test00 未重置——CI 每次新建模拟器所以能过，本地复跑/复用模拟器则 activate 永不再发。现与 test01 一致在测试开头重置标记。

断言保持 `== 1`（防 activate 重复发送回归）；注释注明 test00→test01 的字母序执行依赖。

## 验证

本地（iPhone 17 Pro Max 模拟器，`-only-testing:AdvertTests/AdvertTest`）：

- 旧代码：3 跑 2 挂（test00 事件到达耗时超过固定 5s 等待）
- 新代码：**3 跑 3 过**（7.2s / 8.5s / 1.5s，轮询自适应）

## 合并后（发版流程，与 3.9.1 一致）

1. `gh release create 3.9.2 --target base/3.x --title "v3.9.2"` 发布 GitHub release
2. release published 事件触发 `cocoapods.yml` → `pod trunk push` 两个 podspec
3. growingio-sdk-flutter cdp/2.x 的 SPM 适配 PR 即可锁定 `"3.9.2" ..< "4.0.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)