### PR TITLE
fix(impression): 曝光可见性判定补充祖先裁剪区域

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
+		34A1B0022C9E0A0100IMP002 /* ImpressionTrackTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 34A1B0012C9E0A0100IMP001 /* ImpressionTrackTest.m */; };
 		6F7A64B402BF8E5ED466E56A /* Pods_GrowingAnalyticsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0257123D870B44A9FDA90A22 /* Pods_GrowingAnalyticsTests.framework */; };
 		7E20527CFF34511EE464C33F /* Pods_GrowingAnalyticsStartTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1769255A062869A5D219F683 /* Pods_GrowingAnalyticsStartTests.framework */; };
 		997DAC68973F1F4FAF34EA2E /* Pods_Example_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B524BD63EF3439946134E74 /* Pods_Example_macOS.framework */; };
@@ -470,6 +471,7 @@
 		34B7D649279FA5980003CE04 /* UITableViewAutotrackTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UITableViewAutotrackTest.m; sourceTree = "<group>"; };
 		34B7EB7C27B366B10026B2AF /* gio_hybrideventtest.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = gio_hybrideventtest.html; sourceTree = "<group>"; };
 		34B932342767661600025C94 /* MeasurementProtocol.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MeasurementProtocol.storyboard; sourceTree = "<group>"; };
+		34A1B0012C9E0A0100IMP001 /* ImpressionTrackTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ImpressionTrackTest.m; sourceTree = "<group>"; };
 		34BA7B17277C61250030AC21 /* GrowingAnalyticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GrowingAnalyticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		34BA7B2F277C63D00030AC21 /* ProtobufTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProtobufTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		34BA7B41277D8EC30030AC21 /* DeepLinkTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DeepLinkTest.m; sourceTree = "<group>"; };
@@ -936,6 +938,14 @@
 			path = AdvertisingTests;
 			sourceTree = "<group>";
 		};
+		34A1B0032C9E0A0100IMP003 /* ImpressionTrackTests */ = {
+			isa = PBXGroup;
+			children = (
+				34A1B0012C9E0A0100IMP001 /* ImpressionTrackTest.m */,
+			);
+			path = ImpressionTrackTests;
+			sourceTree = "<group>";
+		};
 		346521E02ADD0E540091E815 /* ABTestingTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1197,6 +1207,7 @@
 				3432CF352AEA58A800E555A9 /* AdvertisingTests */,
 				346521E02ADD0E540091E815 /* ABTestingTests */,
 				04A4C058276C4DF40056C8C4 /* HybridTests */,
+				34A1B0032C9E0A0100IMP003 /* ImpressionTrackTests */,
 				34C0BF3B277EA95A0047ADC4 /* MobileDebuggerTests */,
 				34BA7B30277C63D00030AC21 /* ProtobufTests */,
 				34BA7B43277D91720030AC21 /* WebCircleTests */,
@@ -2987,6 +2998,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				34A1B0022C9E0A0100IMP002 /* ImpressionTrackTest.m in Sources */,
 				34664587278EEEA6009C351C /* A0GrowingAnalyticsTest.m in Sources */,
 				34BF77B227951D6700CA18BA /* InvocationHelper.m in Sources */,
 				34BA7B25277C62ED0030AC21 /* CompressionTest.m in Sources */,

--- a/Example/GrowingAnalyticsTests/ModulesTests/ImpressionTrackTests/ImpressionTrackTest.m
+++ b/Example/GrowingAnalyticsTests/ModulesTests/ImpressionTrackTests/ImpressionTrackTest.m
@@ -1,0 +1,141 @@
+//
+//  ImpressionTrackTest.m
+//  GrowingAnalytics
+//
+//  Created by YoloMao on 2026/9/4.
+//  Copyright (C) 2026 Beijing Yishu Technology Co., Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "Modules/ImpressionTrack/GrowingImpressionTrack.h"
+#import "Modules/ImpressionTrack/Public/UIView+GrowingImpression.h"
+#import "Modules/ImpressionTrack/UIView+GrowingImpressionInternal.h"
+
+@interface ImpressionTrackTest : XCTestCase
+
+@property (nonatomic, strong) UIWindow *window;
+@property (nonatomic, strong) UIScrollView *scrollView;
+
+@end
+
+@implementation ImpressionTrackTest
+
+- (void)setUp {
+    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    [self.window makeKeyAndVisible];
+
+    // scrollView 只占屏幕的一小块,可视区为 window 坐标系下的 (0, 100, 300, 200)
+    self.scrollView = [[UIScrollView alloc] initWithFrame:CGRectMake(0, 100, 300, 200)];
+    self.scrollView.contentSize = CGSizeMake(300, 1000);
+    [self.window addSubview:self.scrollView];
+}
+
+- (void)tearDown {
+    for (UIView *subView in self.scrollView.subviews) {
+        [subView growingStopTrackImpression];
+    }
+    [self.scrollView removeFromSuperview];
+    self.scrollView = nil;
+    self.window.hidden = YES;
+    self.window = nil;
+}
+
+- (UIView *)addItemAtContentY:(CGFloat)y {
+    UIView *item = [[UIView alloc] initWithFrame:CGRectMake(0, y, 100, 50)];
+    [self.scrollView addSubview:item];
+    return item;
+}
+
+#pragma mark - 可见性判定
+
+- (void)testNodeClippedByScrollViewIsInvisible {
+    // contentY 400 => window y 500,已在 scrollView 可视区(100~300)之外,但仍落在屏幕内
+    UIView *item = [self addItemAtContentY:400];
+
+    XCTAssertTrue(self.scrollView.clipsToBounds);
+    CGRect frameInWindow = [item convertRect:item.bounds toView:self.window];
+    XCTAssertTrue(CGRectIntersectsRect(UIScreen.mainScreen.bounds, frameInWindow),
+                  @"前置条件:元素 frame 仍落在屏幕内,否则测不到祖先裁剪逻辑");
+
+    XCTAssertFalse([item growingImpNodeIsVisible]);
+}
+
+- (void)testNodeInsideScrollViewVisibleRectIsVisible {
+    UIView *item = [self addItemAtContentY:10];
+    XCTAssertTrue([item growingImpNodeIsVisible]);
+}
+
+- (void)testNodeBecomesVisibleAfterScrolling {
+    UIView *item = [self addItemAtContentY:400];
+    XCTAssertFalse([item growingImpNodeIsVisible]);
+
+    self.scrollView.contentOffset = CGPointMake(0, 400);
+    XCTAssertTrue([item growingImpNodeIsVisible]);
+}
+
+- (void)testNodeOutsideNonClippingAncestorIsVisible {
+    // 祖先不裁剪时元素确实会绘制出来,不应判为不可见
+    self.scrollView.clipsToBounds = NO;
+    UIView *item = [self addItemAtContentY:400];
+    XCTAssertTrue([item growingImpNodeIsVisible]);
+}
+
+- (void)testNodeWithHiddenAncestorIsInvisible {
+    UIView *item = [self addItemAtContentY:10];
+    self.scrollView.hidden = YES;
+    XCTAssertFalse([item growingImpNodeIsVisible]);
+}
+
+- (void)testNodeWithTransparentAncestorIsInvisible {
+    UIView *item = [self addItemAtContentY:10];
+    self.scrollView.alpha = 0.0;
+    XCTAssertFalse([item growingImpNodeIsVisible]);
+}
+
+#pragma mark - 曝光去重
+
+- (void)testRetrackWithoutAttributesKeepsTrackedFlag {
+    UIView *item = [self addItemAtContentY:10];
+    [item growingTrackImpression:@"imp_track_test"];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    [[GrowingImpressionTrack sharedInstance] performSelector:@selector(impTrack)];
+#pragma clang diagnostic pop
+
+    XCTAssertTrue(item.growingIMPTracked);
+    XCTAssertNil(item.growingIMPTrackVariable, @"attributes 为 nil 时不应被写成空字典,否则去重判断失效");
+
+    // 重复调用不应重置已曝光标记,否则滚动过程中每帧都会重复曝光
+    [item growingTrackImpression:@"imp_track_test"];
+    XCTAssertTrue(item.growingIMPTracked);
+}
+
+- (void)testRetrackWithSameAttributesKeepsTrackedFlag {
+    UIView *item = [self addItemAtContentY:10];
+    [item growingTrackImpression:@"imp_track_test" attributes:@{@"key": @"value"}];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    [[GrowingImpressionTrack sharedInstance] performSelector:@selector(impTrack)];
+#pragma clang diagnostic pop
+
+    XCTAssertTrue(item.growingIMPTracked);
+
+    [item growingTrackImpression:@"imp_track_test" attributes:@{@"key": @"value"}];
+    XCTAssertTrue(item.growingIMPTracked);
+}
+
+@end

--- a/Modules/ImpressionTrack/GrowingImpressionTrack.m
+++ b/Modules/ImpressionTrack/GrowingImpressionTrack.m
@@ -219,14 +219,6 @@ static BOOL impTrackIsRegistered = NO;
 - (void)sendCstm:(UIView<GrowingNode> *)node {
     node.growingIMPTracked = YES;
 
-    NSMutableDictionary *impTrackVariable;
-    if (node.growingIMPTrackVariable.count > 0) {
-        impTrackVariable = node.growingIMPTrackVariable.mutableCopy;
-    } else {
-        impTrackVariable = [[NSMutableDictionary alloc] init];
-    }
-    node.growingIMPTrackVariable = impTrackVariable;
-
     if (node.growingIMPTrackEventName.length > 0 && node.growingIMPTrackVariable.count > 0) {
         [GrowingEventGenerator generateCustomEvent:node.growingIMPTrackEventName
                                         attributes:node.growingIMPTrackVariable];

--- a/Modules/ImpressionTrack/UIView+GrowingImpressionInternal.m
+++ b/Modules/ImpressionTrack/UIView+GrowingImpressionInternal.m
@@ -61,19 +61,45 @@
     objc_setAssociatedObject(self, @selector(growingIMPTrackVariable), variable, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
+// 沿视图层级向上逐层收窄可见区域,返回 keyWindow 坐标系下的矩形
+// 存在隐藏/透明的祖先,或已被祖先完全裁剪掉时,返回 CGRectNull
+- (CGRect)growingImpVisibleRectInWindow {
+    CGRect rect = [self growingNodeFrame];
+
+    UIResponder *curNode = self.nextResponder;
+    while (curNode) {
+        if (!curNode.isProxy && [curNode isKindOfClass:[UIView class]]) {
+            UIView *ancestor = (UIView *)curNode;
+            if (ancestor.hidden == YES || ancestor.alpha < 0.001) {
+                return CGRectNull;
+            }
+            if (ancestor.clipsToBounds) {
+                rect = CGRectIntersection(rect, [ancestor growingNodeFrame]);
+                if (CGRectIsEmpty(rect) || CGRectIsNull(rect)) {
+                    return CGRectNull;
+                }
+            }
+        }
+        curNode = curNode.nextResponder;
+    }
+
+    return rect;
+}
+
 - (BOOL)growingImpNodeIsVisible {
     if (!self.window || self.hidden || self.alpha < 0.001 || !self.superview) {
         return NO;
     }
 
-    CGRect rect = [self growingNodeFrame];
+    // 只与屏幕求交不足以判定可见:被 UIScrollView 等容器裁掉的子视图,
+    // 其 frame 仍可能落在屏幕内,需先由祖先的裁剪区域收窄
+    CGRect rect = [self growingImpVisibleRectInWindow];
     CGRect intersectionRect = CGRectIntersection([UIScreen mainScreen].bounds, rect);
 
     if (CGRectIsEmpty(intersectionRect) || CGRectIsNull(intersectionRect)) {
         return NO;
     }
 
-    BOOL isInScreen;
     double impScale = 0.0;
     GrowingTrackConfiguration *configuration = GrowingConfigurationManager.sharedInstance.trackConfiguration;
     if ([configuration isKindOfClass:[GrowingAutotrackConfiguration class]]) {
@@ -81,30 +107,11 @@
     }
 
     if (impScale == 0.0) {
-        isInScreen = YES;
-    } else {
-        if (intersectionRect.size.width * intersectionRect.size.height >=
-            self.bounds.size.width * self.bounds.size.height * impScale) {
-            isInScreen = YES;
-        } else {
-            isInScreen = NO;
-        }
-    }
-
-    if (isInScreen) {
-        UIResponder *curNode = self.nextResponder;
-        while (curNode) {
-            if (!curNode.isProxy && [curNode isKindOfClass:[UIView class]]) {
-                if (((UIView *)curNode).hidden == YES || ((UIView *)curNode).alpha < 0.001) {
-                    return NO;
-                }
-            }
-            curNode = curNode.nextResponder;
-        }
         return YES;
     }
 
-    return NO;
+    return intersectionRect.size.width * intersectionRect.size.height >=
+           self.bounds.size.width * self.bounds.size.height * impScale;
 }
 
 - (void)growingTrackImpression:(NSString *)eventName {


### PR DESCRIPTION
## 问题

`growingImpNodeIsVisible` 此前只把元素 frame 与 `[UIScreen mainScreen].bounds` 求交，向上遍历祖先时也仅检查 `hidden`/`alpha`，**完全不考虑 `clipsToBounds` 裁剪**。

而 UIScrollView 让内容"看不见"靠的正是裁剪：被裁掉的子视图 `hidden` 为 NO、`alpha` 为 1、`window` 也在，转换后的 frame 依然是屏幕内的合法矩形，于是被判为可见并触发曝光。

scrollView 高度小于屏幕高度时，**可视区与屏幕之间那段区间里的元素全部误报**。以 scrollView frame `(0, 100, 300, 200)`、内容总高 900 为例：

| 元素 | content 内 y | 转到 window 后 y | 屏幕内 | 用户实际可见 | 修复前判定 |
|---|---|---|---|---|---|
| 第 1 行 | 0 | 100 | 是 | ✅ | 可见 ✅ |
| 第 4 行 | 400 | 500 | **是** | ❌ 被裁掉 | **可见 ❌** |
| 第 7 行 | 700 | 900 | 否 | ❌ | 不可见 ✅ |

网格排列的列表尤为明显：屏幕内展示不全时，尚未滚动到的元素会提前上报曝光。

## 改动

**1. 可见性判定补充祖先裁剪区域**（`UIView+GrowingImpressionInternal.m`）

新增 `growingImpVisibleRectInWindow`，把原来只查 `hidden`/`alpha` 的 `nextResponder` 上溯循环，扩展成同时逐层收窄可见矩形：遇到 `clipsToBounds` 的祖先就与其 `growingNodeFrame` 求交，交集为空即判定不可见。`growingImpNodeIsVisible` 改为先取这个裁剪后的矩形，再与屏幕求交。

对 UIScrollView / UITableView / UICollectionView 以及任何自定义裁剪容器一次性生效。

> 副带效果：`impressionScale` 终于符合其文档语义「元素可见面积 / 元素总面积」。此前分子取的是**屏幕内**面积，与裁剪无关，所以在 scrollView 场景下配置阈值也无济于事。

**2. 修复 `sendCstm:` 把 nil 的 `growingIMPTrackVariable` 写成空字典**（`GrowingImpressionTrack.m`）

该赋值本身无用（`mutableCopy` 之后从未修改），却让 `growingTrackImpression:attributes:` 的去重判断 `(attributes == nil && growingIMPTrackVariable == nil)` 永远不成立 —— 首次曝光后 `growingIMPTrackVariable` 已非 nil。结果是 **`attributes` 传 nil 时重复调用会重置 `growingIMPTracked` 并再次曝光**，在 `scrollViewDidScroll:` 等高频回调里调用会每帧重复上报。`attributes` 非 nil 时走 `isEqualToDictionary:` 分支，去重原本正常。

**3. 新增 `ImpressionTrackTest`**（8 例，已注册进 `Example.xcodeproj` 的 `GrowingAnalyticsTests` target）

## 验证

iPhone 17 Pro 模拟器，跑了两遍：修复后 **8/8 通过**；把 `Modules/` 的改动 stash 掉再跑，正好 **3 例失败、5 例仍通过**。

| 用例 | 无修复 | 有修复 |
|---|---|---|
| `testNodeClippedByScrollViewIsInvisible` | ❌ | ✅ |
| `testNodeBecomesVisibleAfterScrolling` | ❌ | ✅ |
| `testRetrackWithoutAttributesKeepsTrackedFlag` | ❌ | ✅ |
| `testNodeInsideScrollViewVisibleRectIsVisible` | ✅ | ✅ |
| `testNodeOutsideNonClippingAncestorIsVisible` | ✅ | ✅ |
| `testNodeWithHiddenAncestorIsInvisible` | ✅ | ✅ |
| `testNodeWithTransparentAncestorIsInvisible` | ✅ | ✅ |
| `testRetrackWithSameAttributesKeepsTrackedFlag` | ✅ | ✅ |

后 5 例守住既有行为：可视区内正常曝光、祖先 `clipsToBounds = NO` 时不误判为不可见（元素确实会绘制出来）、祖先 `hidden`/`alpha = 0` 的原有拦截保持不变。

## 已知未覆盖

本次不处理 **z 序遮挡** —— 元素被同级兄弟视图、TabBar、弹窗盖住时仍会算作可见。这是另一个独立问题，需要的话另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U46BWUW7wppZQW2fc28JS
